### PR TITLE
Add fast mode for running benchmarks (used for testing)

### DIFF
--- a/astropy_healpix/bench.py
+++ b/astropy_healpix/bench.py
@@ -60,7 +60,7 @@ def get_import(package, fct):
         return 'from healpy import {}'.format(fct)
 
 
-def bench_pix2ang(size, nside, nest, package):
+def bench_pix2ang(size, nside, nest, package, fast=False):
     shape = (int(size), )
 
     setup = '\n'.join([
@@ -72,10 +72,10 @@ def bench_pix2ang(size, nside, nest, package):
 
     stmt = 'pix2ang(nside, ipix, nest)'
 
-    return autotimeit(stmt=stmt, setup=setup, repeat=1, mintime=0.1)
+    return autotimeit(stmt=stmt, setup=setup, repeat=1, mintime=0 if fast else 0.1)
 
 
-def bench_run():
+def bench_run(fast=False):
     """Run all benchmarks. Return results as a dict."""
     results = []
 
@@ -84,14 +84,16 @@ def bench_run():
             for nside in [1, 128]:
 
                 time_self = bench_pix2ang(size=size, nside=nside,
-                                          nest=nest, package='astropy_healpix')
+                                          nest=nest, package='astropy_healpix',
+                                          fast=fast)
 
                 results_single = dict(fct='pix2ang', size=int(size),
                                       nside=nside, time_self=time_self)
 
                 if HEALPY_INSTALLED:
                     time_healpy = bench_pix2ang(size=size, nside=nside,
-                                                nest=nest, package='healpy')
+                                                nest=nest, package='healpy',
+                                                fast=fast)
                     results_single['time_healpy'] = time_healpy
 
                 results.append(results_single)
@@ -113,10 +115,10 @@ def bench_report(results):
     table.pprint(max_lines=-1)
 
 
-def main():
+def main(fast=False):
     """Run all benchmarks and print report to the console."""
     print('Running benchmarks...\n')
-    results = bench_run()
+    results = bench_run(fast=fast)
     bench_report(results)
 
 

--- a/astropy_healpix/tests/test_bench.py
+++ b/astropy_healpix/tests/test_bench.py
@@ -4,4 +4,4 @@ from ..bench import main
 
 
 def test_bench():
-    main()
+    main(fast=True)


### PR DESCRIPTION
@cdeil - this implements what I was suggesting in https://github.com/astropy/astropy-healpix/issues/22#issuecomment-333340017 - namely a 'fast' mode to just make sure the benchmarks run, which is then used in testing. This flag could also be used for example to skip larger array sizes if we decide to add some.

Note that I also made it so the benchmarks do run even if healpy is not installed - this is to be absolutely in the clear license-wise and make healpy as optional as possible (i.e nothing breaks if it's not installed). Here's a run without healpy:

```
Running benchmarks...

  fct   nside   size  time_self 
------- ----- ------- ----------
pix2ang     1      10  0.0010800
pix2ang   128      10  0.0004873
pix2ang     1    1000  0.0005073
pix2ang   128    1000  0.0004769
pix2ang     1 1000000  0.1681630
pix2ang   128 1000000  0.1451594
pix2ang     1      10  0.0005421
pix2ang   128      10  0.0003970
pix2ang     1    1000  0.0005431
pix2ang   128    1000  0.0005563
pix2ang     1 1000000  0.1548071
pix2ang   128 1000000  0.1714707
```

Basically the healpy column and ratio are missing in this case. It's still useful to see how the speed changes with nside and size.