### PR TITLE
Use OpenMP in Cython wrappers

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "astropy_helpers"]
 	path = astropy_helpers
-	url = https://github.com/astropy/astropy-helpers.git
+	url = https://github.com/astrofrog/astropy-helpers.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "astropy_helpers"]
 	path = astropy_helpers
-	url = https://github.com/astrofrog/astropy-helpers.git
+	url = https://github.com/astropy/astropy-helpers.git

--- a/.run_docker_tests.sh
+++ b/.run_docker_tests.sh
@@ -16,6 +16,9 @@ uname -m
 echo "Output of sys.maxsize in Python:"
 python -c 'import sys; print(sys.maxsize)'
 
+apt-get update
+apt-get install -y git
+
 # We only test the docs output on 64-bit Linux so as not to have to 
 # degrade the output with ellipses to work on all platforms.
 python setup.py test -V -a "-s" --skip-docs

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 0.2 (unreleased)
 ================
 
-- No changes yet.
+- Use OpenMP to parallelize the Cython wrappers. [#59]
 
 0.1 (2017-10-01)
 ================

--- a/astropy_healpix/bench.py
+++ b/astropy_healpix/bench.py
@@ -88,7 +88,7 @@ def bench_run(fast=False):
                                           fast=fast)
 
                 results_single = dict(fct='pix2ang', size=int(size),
-                                      nside=nside, time_self=time_self)
+                                      nside=nside, time_self=time_self, nest=nest)
 
                 if HEALPY_INSTALLED:
                     time_healpy = bench_pix2ang(size=size, nside=nside,

--- a/astropy_healpix/conftest.py
+++ b/astropy_healpix/conftest.py
@@ -25,6 +25,7 @@ enable_deprecations_as_exceptions()
 try:
     PYTEST_HEADER_MODULES['Astropy'] = 'astropy'
     PYTEST_HEADER_MODULES['healpy'] = 'healpy'
+    PYTEST_HEADER_MODULES['Cython'] = 'cython'
     del PYTEST_HEADER_MODULES['h5py']
     del PYTEST_HEADER_MODULES['Pandas']
 except (NameError, KeyError):  # NameError is needed to support Astropy < 1.0

--- a/astropy_healpix/core_cython.pxd
+++ b/astropy_healpix/core_cython.pxd
@@ -8,16 +8,16 @@ from numpy cimport int64_t
 cdef extern from "healpix.h":
 
     # Converts a healpix index from the XY scheme to the RING scheme.
-    int64_t healpixl_xy_to_ring(int64_t hp, int Nside);
+    int64_t healpixl_xy_to_ring(int64_t hp, int Nside) nogil
 
     # Converts a healpix index from the RING scheme to the XY scheme.
-    int64_t healpixl_ring_to_xy(int64_t ring_index, int Nside);
+    int64_t healpixl_ring_to_xy(int64_t ring_index, int Nside) nogil
 
     # Converts a healpix index from the XY scheme to the NESTED scheme.
-    int64_t healpixl_xy_to_nested(int64_t hp, int Nside);
+    int64_t healpixl_xy_to_nested(int64_t hp, int Nside) nogil
 
     # Converts a healpix index from the NESTED scheme to the XY scheme.
-    int64_t healpixl_nested_to_xy(int64_t nested_index, int Nside);
+    int64_t healpixl_nested_to_xy(int64_t nested_index, int Nside) nogil
 
     #  Converts a healpix index, plus fractional offsets (dx,dy), into (x,y,z)
     #  coordinates on the unit sphere.  (dx,dy) must be in [0, 1].  (0.5, 0.5)
@@ -25,10 +25,10 @@ cdef extern from "healpix.h":
     #  the northernmost corner, (1,0) is the easternmost, and (0,1) the
     #  westernmost.
     void healpixl_to_radec(int64_t hp, int Nside, double dx, double dy,
-                           double* ra, double* dec);
+                           double* ra, double* dec) nogil
 
     # Converts (RA, DEC) coordinates (in radians) to healpix XY index
-    int64_t radec_to_healpixlf(double ra, double dec, int Nside, double* dx, double* dy);
+    int64_t radec_to_healpixlf(double ra, double dec, int Nside, double* dx, double* dy) nogil
 
     # Finds the healpixes neighbouring the given healpix, placing them in the
     # array "neighbour".  Returns the number of neighbours.  You must ensure
@@ -36,6 +36,6 @@ cdef extern from "healpix.h":
     #
     # Healpixes in the interior of a large healpix will have eight neighbours;
     # pixels near the edges can have fewer.
-    int healpixl_get_neighbours(int64_t hp, int64_t* neighbours, int Nside);
+    int healpixl_get_neighbours(int64_t hp, int64_t* neighbours, int Nside) nogil
 
-    int healpix_rangesearch_radec_simple(double ra, double dec, double radius, int Nside, int approx, int64_t** indices)
+    int healpix_rangesearch_radec_simple(double ra, double dec, double radius, int Nside, int approx, int64_t** indices) nogil

--- a/astropy_healpix/core_cython.pyx
+++ b/astropy_healpix/core_cython.pyx
@@ -326,7 +326,8 @@ def interpolate_bilinear_lonlat(np.ndarray[double_t, ndim=1, mode="c"] lon,
     # context. Note that we also need to do this for dx_buf and dy_buf otherwise
     # if we just passed &dx and &dy to radec_to_healpixlf, different threads
     # would be accessing the same location in memory, causing issues.
-    cdef double *dx_buf, *dy_buf
+    cdef double *dx_buf
+    cdef double *dy_buf
     cdef int64_t * neighbours
 
     if npix % 12 != 0:

--- a/astropy_healpix/core_cython.pyx
+++ b/astropy_healpix/core_cython.pyx
@@ -8,6 +8,7 @@ strict and the functions will fail if the incorrect types are passed in.
 import numpy as np
 cimport numpy as np
 import cython
+from cython.parallel import prange
 
 ctypedef np.intp_t intp_t
 ctypedef np.double_t double_t
@@ -67,17 +68,18 @@ def healpix_to_lonlat(np.ndarray[int64_t, ndim=1, mode="c"] healpix_index,
     order = _validate_order(order)
 
     if order == 'nested':
-        for i in range(n):
+        for i in prange(n, nogil=True):
             xy_index = healpixl_nested_to_xy(healpix_index[i], nside)
             healpixl_to_radec(xy_index, nside, dx, dy, &lon[i], &lat[i])
     elif order == 'ring':
-        for i in range(n):
+        for i in prange(n, nogil=True):
             xy_index = healpixl_ring_to_xy(healpix_index[i], nside)
             healpixl_to_radec(xy_index, nside, dx, dy, &lon[i], &lat[i])
 
     return lon, lat
 
 
+@cython.boundscheck(False)
 def healpix_with_offset_to_lonlat(np.ndarray[int64_t, ndim=1, mode="c"] healpix_index,
                                   np.ndarray[double_t, ndim=1, mode="c"] dx,
                                   np.ndarray[double_t, ndim=1, mode="c"] dy,
@@ -117,17 +119,18 @@ def healpix_with_offset_to_lonlat(np.ndarray[int64_t, ndim=1, mode="c"] healpix_
     order = _validate_order(order)
 
     if order == 'nested':
-        for i in range(n):
+        for i in prange(n, nogil=True):
             xy_index = healpixl_nested_to_xy(healpix_index[i], nside)
             healpixl_to_radec(xy_index, nside, dx[i], dy[i], &lon[i], &lat[i])
     elif order == 'ring':
-        for i in range(n):
+        for i in prange(n, nogil=True):
             xy_index = healpixl_ring_to_xy(healpix_index[i], nside)
             healpixl_to_radec(xy_index, nside, dx[i], dy[i], &lon[i], &lat[i])
 
     return lon, lat
 
 
+@cython.boundscheck(False)
 def lonlat_to_healpix(np.ndarray[double_t, ndim=1, mode="c"] lon,
                       np.ndarray[double_t, ndim=1, mode="c"] lat,
                       int nside, str order):
@@ -162,17 +165,18 @@ def lonlat_to_healpix(np.ndarray[double_t, ndim=1, mode="c"] lon,
     order = _validate_order(order)
 
     if order == 'nested':
-        for i in range(n):
+        for i in prange(n, nogil=True):
             xy_index = radec_to_healpixlf(lon[i], lat[i], nside, &dx, &dy)
             healpix_index[i] = healpixl_xy_to_nested(xy_index, nside)
     elif order == 'ring':
-        for i in range(n):
+        for i in prange(n, nogil=True):
             xy_index = radec_to_healpixlf(lon[i], lat[i], nside, &dx, &dy)
             healpix_index[i] = healpixl_xy_to_ring(xy_index, nside)
 
     return healpix_index
 
 
+@cython.boundscheck(False)
 def lonlat_to_healpix_with_offset(np.ndarray[double_t, ndim=1, mode="c"] lon,
                                   np.ndarray[double_t, ndim=1, mode="c"] lat,
                                   int nside, str order):
@@ -210,17 +214,18 @@ def lonlat_to_healpix_with_offset(np.ndarray[double_t, ndim=1, mode="c"] lon,
     order = _validate_order(order)
 
     if order == 'nested':
-        for i in range(n):
+        for i in prange(n, nogil=True):
             xy_index = radec_to_healpixlf(lon[i], lat[i], nside, &dx[i], &dy[i])
             healpix_index[i] = healpixl_xy_to_nested(xy_index, nside)
     elif order == 'ring':
-        for i in range(n):
+        for i in prange(n, nogil=True):
             xy_index = radec_to_healpixlf(lon[i], lat[i], nside, &dx[i], &dy[i])
             healpix_index[i] = healpixl_xy_to_ring(xy_index, nside)
 
     return healpix_index, dx, dy
 
 
+@cython.boundscheck(False)
 def nested_to_ring(np.ndarray[int64_t, ndim=1, mode="c"] nested_index, int nside):
     """
     Convert a HEALPix 'nested' index to a HEALPix 'ring' index
@@ -242,12 +247,13 @@ def nested_to_ring(np.ndarray[int64_t, ndim=1, mode="c"] nested_index, int nside
     cdef intp_t i
     cdef np.ndarray[int64_t, ndim=1, mode="c"] ring_index = np.zeros(n, dtype=npy_int64)
 
-    for i in range(n):
+    for i in prange(n, nogil=True):
         ring_index[i] = healpixl_xy_to_ring(healpixl_nested_to_xy(nested_index[i], nside), nside)
 
     return ring_index
 
 
+@cython.boundscheck(False)
 def ring_to_nested(np.ndarray[int64_t, ndim=1, mode="c"] ring_index, int nside):
     """
     Convert a HEALPix 'ring' index to a HEALPix 'nested' index
@@ -269,12 +275,13 @@ def ring_to_nested(np.ndarray[int64_t, ndim=1, mode="c"] ring_index, int nside):
     cdef intp_t i
     cdef np.ndarray[int64_t, ndim=1, mode="c"] nested_index = np.zeros(n, dtype=npy_int64)
 
-    for i in range(n):
+    for i in prange(n, nogil=True):
         nested_index[i] = healpixl_xy_to_nested(healpixl_ring_to_xy(ring_index[i], nside), nside)
 
     return nested_index
 
 
+@cython.boundscheck(False)
 def interpolate_bilinear_lonlat(np.ndarray[double_t, ndim=1, mode="c"] lon,
                                 np.ndarray[double_t, ndim=1, mode="c"] lat,
                                 np.ndarray[double_t, ndim=1, mode="c"] values,
@@ -331,7 +338,7 @@ def interpolate_bilinear_lonlat(np.ndarray[double_t, ndim=1, mode="c"] lon,
     elif order == 'ring':
         order_int = 1
 
-    for i in range(n):
+    for i in prange(n, nogil=True):
 
         xy_index = radec_to_healpixlf(lon[i], lat[i], nside, &dx, &dy)
 
@@ -406,6 +413,7 @@ def interpolate_bilinear_lonlat(np.ndarray[double_t, ndim=1, mode="c"] lon,
     return result
 
 
+@cython.boundscheck(False)
 def healpix_neighbors(np.ndarray[int64_t, ndim=1, mode="c"] healpix_index,
                        int nside, str order):
     """
@@ -452,7 +460,7 @@ def healpix_neighbors(np.ndarray[int64_t, ndim=1, mode="c"] healpix_index,
 
     if order == 'nested':
 
-        for i in range(n):
+        for i in prange(n, nogil=True):
 
             xy_index = healpixl_nested_to_xy(healpix_index[i], nside)
             healpixl_get_neighbours(xy_index, neighbours_indiv, nside)
@@ -468,7 +476,7 @@ def healpix_neighbors(np.ndarray[int64_t, ndim=1, mode="c"] healpix_index,
 
     elif order == 'ring':
 
-        for i in range(n):
+        for i in prange(n, nogil=True):
 
             xy_index = healpixl_ring_to_xy(healpix_index[i], nside)
 
@@ -486,6 +494,7 @@ def healpix_neighbors(np.ndarray[int64_t, ndim=1, mode="c"] healpix_index,
     return neighbours
 
 
+@cython.boundscheck(False)
 def healpix_cone_search(double lon, double lat, double radius, int nside, str order):
     """
     Find all the HEALPix pixels within a given radius of a longitude/latitude.
@@ -523,11 +532,11 @@ def healpix_cone_search(double lon, double lat, double radius, int nside, str or
     order = _validate_order(order)
 
     if order == 'nested':
-        for i in range(n_indices):
+        for i in prange(n_indices, nogil=True):
             index = indices[i]
             result[i] = healpixl_xy_to_nested(index, nside)
     elif order == 'ring':
-        for i in range(n_indices):
+        for i in prange(n_indices, nogil=True):
             index = indices[i]
             result[i] = healpixl_xy_to_ring(index, nside)
 

--- a/astropy_healpix/core_cython.pyx
+++ b/astropy_healpix/core_cython.pyx
@@ -69,11 +69,11 @@ def healpix_to_lonlat(np.ndarray[int64_t, ndim=1, mode="c"] healpix_index,
     order = _validate_order(order)
 
     if order == 'nested':
-        for i in prange(n, nogil=True):
+        for i in prange(n, nogil=True, schedule='static'):
             xy_index = healpixl_nested_to_xy(healpix_index[i], nside)
             healpixl_to_radec(xy_index, nside, dx, dy, &lon[i], &lat[i])
     elif order == 'ring':
-        for i in prange(n, nogil=True):
+        for i in prange(n, nogil=True, schedule='static'):
             xy_index = healpixl_ring_to_xy(healpix_index[i], nside)
             healpixl_to_radec(xy_index, nside, dx, dy, &lon[i], &lat[i])
 
@@ -120,11 +120,11 @@ def healpix_with_offset_to_lonlat(np.ndarray[int64_t, ndim=1, mode="c"] healpix_
     order = _validate_order(order)
 
     if order == 'nested':
-        for i in prange(n, nogil=True):
+        for i in prange(n, nogil=True, schedule='static'):
             xy_index = healpixl_nested_to_xy(healpix_index[i], nside)
             healpixl_to_radec(xy_index, nside, dx[i], dy[i], &lon[i], &lat[i])
     elif order == 'ring':
-        for i in prange(n, nogil=True):
+        for i in prange(n, nogil=True, schedule='static'):
             xy_index = healpixl_ring_to_xy(healpix_index[i], nside)
             healpixl_to_radec(xy_index, nside, dx[i], dy[i], &lon[i], &lat[i])
 
@@ -166,11 +166,11 @@ def lonlat_to_healpix(np.ndarray[double_t, ndim=1, mode="c"] lon,
     order = _validate_order(order)
 
     if order == 'nested':
-        for i in prange(n, nogil=True):
+        for i in prange(n, nogil=True, schedule='static'):
             xy_index = radec_to_healpixlf(lon[i], lat[i], nside, &dx, &dy)
             healpix_index[i] = healpixl_xy_to_nested(xy_index, nside)
     elif order == 'ring':
-        for i in prange(n, nogil=True):
+        for i in prange(n, nogil=True, schedule='static'):
             xy_index = radec_to_healpixlf(lon[i], lat[i], nside, &dx, &dy)
             healpix_index[i] = healpixl_xy_to_ring(xy_index, nside)
 
@@ -215,11 +215,11 @@ def lonlat_to_healpix_with_offset(np.ndarray[double_t, ndim=1, mode="c"] lon,
     order = _validate_order(order)
 
     if order == 'nested':
-        for i in prange(n, nogil=True):
+        for i in prange(n, nogil=True, schedule='static'):
             xy_index = radec_to_healpixlf(lon[i], lat[i], nside, &dx[i], &dy[i])
             healpix_index[i] = healpixl_xy_to_nested(xy_index, nside)
     elif order == 'ring':
-        for i in prange(n, nogil=True):
+        for i in prange(n, nogil=True, schedule='static'):
             xy_index = radec_to_healpixlf(lon[i], lat[i], nside, &dx[i], &dy[i])
             healpix_index[i] = healpixl_xy_to_ring(xy_index, nside)
 
@@ -248,7 +248,7 @@ def nested_to_ring(np.ndarray[int64_t, ndim=1, mode="c"] nested_index, int nside
     cdef intp_t i
     cdef np.ndarray[int64_t, ndim=1, mode="c"] ring_index = np.zeros(n, dtype=npy_int64)
 
-    for i in prange(n, nogil=True):
+    for i in prange(n, nogil=True, schedule='static'):
         ring_index[i] = healpixl_xy_to_ring(healpixl_nested_to_xy(nested_index[i], nside), nside)
 
     return ring_index
@@ -276,7 +276,7 @@ def ring_to_nested(np.ndarray[int64_t, ndim=1, mode="c"] ring_index, int nside):
     cdef intp_t i
     cdef np.ndarray[int64_t, ndim=1, mode="c"] nested_index = np.zeros(n, dtype=npy_int64)
 
-    for i in prange(n, nogil=True):
+    for i in prange(n, nogil=True, schedule='static'):
         nested_index[i] = healpixl_xy_to_nested(healpixl_ring_to_xy(ring_index[i], nside), nside)
 
     return nested_index
@@ -347,7 +347,7 @@ def interpolate_bilinear_lonlat(np.ndarray[double_t, ndim=1, mode="c"] lon,
         if neighbours == NULL:
             abort()
 
-        for i in prange(n):
+        for i in prange(n, schedule='static'):
 
             xy_index = radec_to_healpixlf(lon[i], lat[i], nside, &dx, &dy)
 
@@ -484,7 +484,7 @@ def healpix_neighbors(np.ndarray[int64_t, ndim=1, mode="c"] healpix_index,
 
         if order_int == 0:
 
-            for i in prange(n):
+            for i in prange(n, schedule='static'):
 
                 xy_index = healpixl_nested_to_xy(healpix_index[i], nside)
                 healpixl_get_neighbours(xy_index, neighbours_indiv, nside)
@@ -500,7 +500,7 @@ def healpix_neighbors(np.ndarray[int64_t, ndim=1, mode="c"] healpix_index,
 
         elif order_int == 1:
 
-            for i in prange(n):
+            for i in prange(n, schedule='static'):
 
                 xy_index = healpixl_ring_to_xy(healpix_index[i], nside)
 
@@ -558,11 +558,11 @@ def healpix_cone_search(double lon, double lat, double radius, int nside, str or
     order = _validate_order(order)
 
     if order == 'nested':
-        for i in prange(n_indices, nogil=True):
+        for i in prange(n_indices, nogil=True, schedule='static'):
             index = indices[i]
             result[i] = healpixl_xy_to_nested(index, nside)
     elif order == 'ring':
-        for i in prange(n_indices, nogil=True):
+        for i in prange(n_indices, nogil=True, schedule='static'):
             index = indices[i]
             result[i] = healpixl_xy_to_ring(index, nside)
 

--- a/astropy_healpix/core_cython.pyx
+++ b/astropy_healpix/core_cython.pyx
@@ -325,7 +325,9 @@ def interpolate_bilinear_lonlat(np.ndarray[double_t, ndim=1, mode="c"] lon,
     # sure that any temporary buffers are allocated inside the parallel()
     # context. Note that we also need to do this for dx_buf and dy_buf otherwise
     # if we just passed &dx and &dy to radec_to_healpixlf, different threads
-    # would be accessing the same location in memory, causing issues.
+    # would be accessing the same location in memory, causing issues. We use
+    # manual memory management with malloc as this appears to be the recommended
+    # method at http://cython.readthedocs.io/en/latest/src/userguide/parallelism.html
     cdef double *dx_buf
     cdef double *dy_buf
     cdef int64_t * neighbours

--- a/astropy_healpix/setup_package.py
+++ b/astropy_healpix/setup_package.py
@@ -34,6 +34,9 @@ def get_extensions():
         include_dirs=include_dirs,
         libraries=libraries,
         language="c",
-        extra_compile_args=['-O2'])
+        extra_compile_args=['-fopenmp'],
+        extra_link_args=['-fopenmp'])
+
+        # extra_compile_args=['-O2'])
 
     return [extension]

--- a/astropy_healpix/setup_package.py
+++ b/astropy_healpix/setup_package.py
@@ -1,9 +1,44 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
+# This file incldues code adapted from astroscrappy, originally released under
+# the following license:
+#
+# Copyright (c) 2015, Curtis McCully
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+# * Redistributions in binary form must reproduce the above copyright notice, this
+#   list of conditions and the following disclaimer in the documentation and/or
+#   other materials provided with the distribution.
+# * Neither the name of the Astropy Team nor the names of its contributors may be
+#   used to endorse or promote products derived from this software without
+#   specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 from __future__ import absolute_import, print_function, division
 
 import os
+import tempfile
+
+from distutils import log
 from distutils.core import Extension
+from distutils.ccompiler import new_compiler
+from distutils.sysconfig import customize_compiler
+
 
 HEALPIX_ROOT = os.path.relpath(os.path.dirname(__file__))
 
@@ -18,6 +53,36 @@ C_FILES = ['bl.c',
 
 C_DIR = os.path.join('cextern', 'astrometry.net')
 
+CCODE = """
+#include <omp.h>
+#include <stdio.h>
+int main() {
+#pragma omp parallel
+printf("nthreads=%d\\n", omp_get_num_threads());
+}
+"""
+
+
+def get_openmp_flags():
+
+    ccompiler = new_compiler()
+    customize_compiler(ccompiler)
+
+    filename = tempfile.mktemp(suffix='.c')
+
+    with open(filename, 'w') as f:
+        f.write(CCODE)
+
+    for flag in ['-fopenmp', '-openmp']:
+
+        try:
+            ccompiler.compile([filename], extra_postargs=[flag])
+            return [flag]
+        except:
+            pass
+
+    return None
+
 
 def get_extensions():
 
@@ -28,16 +93,25 @@ def get_extensions():
 
     include_dirs = ['numpy', C_DIR]
 
+    compile_args = ['-O2']
+    link_args = []
+
+    openmp_flags = get_openmp_flags()
+
+    if openmp_flags is None:
+        log.warn("Cannot compile Cython extension with OpenMP, reverting to non-parallel code")
+    else:
+        log.info("Compiling Cython extension with OpenMP support")
+        compile_args.extend(openmp_flags)
+        link_args.extend(openmp_flags)
+
     extension = Extension(
         name="astropy_healpix.core_cython",
         sources=sources,
         include_dirs=include_dirs,
         libraries=libraries,
         language="c",
-        extra_compile_args=['-fopenmp', '-O2'],
-        extra_link_args=['-fopenmp'])
-
-        # extra_compile_args=['-O2'])
-
+        extra_compile_args=compile_args,
+        extra_link_args=link_args)
 
     return [extension]

--- a/astropy_healpix/setup_package.py
+++ b/astropy_healpix/setup_package.py
@@ -1,44 +1,9 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-# This file incldues code adapted from astroscrappy, originally released under
-# the following license:
-#
-# Copyright (c) 2015, Curtis McCully
-# All rights reserved.
-#
-# Redistribution and use in source and binary forms, with or without modification,
-# are permitted provided that the following conditions are met:
-#
-# * Redistributions of source code must retain the above copyright notice, this
-#   list of conditions and the following disclaimer.
-# * Redistributions in binary form must reproduce the above copyright notice, this
-#   list of conditions and the following disclaimer in the documentation and/or
-#   other materials provided with the distribution.
-# * Neither the name of the Astropy Team nor the names of its contributors may be
-#   used to endorse or promote products derived from this software without
-#   specific prior written permission.
-#
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
-# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-from __future__ import absolute_import, print_function, division
-
 import os
-import tempfile
 
-from distutils import log
 from distutils.core import Extension
-from distutils.ccompiler import new_compiler
-from distutils.sysconfig import customize_compiler
-
+from astropy_helpers.openmp_helpers import add_openmp_flags_if_available
 
 HEALPIX_ROOT = os.path.relpath(os.path.dirname(__file__))
 
@@ -53,36 +18,6 @@ C_FILES = ['bl.c',
 
 C_DIR = os.path.join('cextern', 'astrometry.net')
 
-CCODE = """
-#include <omp.h>
-#include <stdio.h>
-int main() {
-#pragma omp parallel
-printf("nthreads=%d\\n", omp_get_num_threads());
-}
-"""
-
-
-def get_openmp_flags():
-
-    ccompiler = new_compiler()
-    customize_compiler(ccompiler)
-
-    filename = tempfile.mktemp(suffix='.c')
-
-    with open(filename, 'w') as f:
-        f.write(CCODE)
-
-    for flag in ['-fopenmp', '-openmp']:
-
-        try:
-            ccompiler.compile([filename], extra_postargs=[flag])
-            return [flag]
-        except:
-            pass
-
-    return None
-
 
 def get_extensions():
 
@@ -93,25 +28,14 @@ def get_extensions():
 
     include_dirs = ['numpy', C_DIR]
 
-    compile_args = ['-O2']
-    link_args = []
-
-    openmp_flags = get_openmp_flags()
-
-    if openmp_flags is None:
-        log.warn("Cannot compile Cython extension with OpenMP, reverting to non-parallel code")
-    else:
-        log.info("Compiling Cython extension with OpenMP support")
-        compile_args.extend(openmp_flags)
-        link_args.extend(openmp_flags)
-
     extension = Extension(
         name="astropy_healpix.core_cython",
         sources=sources,
         include_dirs=include_dirs,
         libraries=libraries,
         language="c",
-        extra_compile_args=compile_args,
-        extra_link_args=link_args)
+        extra_compile_args=['-O2'])
+
+    add_openmp_flags_if_available(extension)
 
     return [extension]

--- a/astropy_healpix/setup_package.py
+++ b/astropy_healpix/setup_package.py
@@ -34,9 +34,10 @@ def get_extensions():
         include_dirs=include_dirs,
         libraries=libraries,
         language="c",
-        extra_compile_args=['-fopenmp'],
+        extra_compile_args=['-fopenmp', '-O2'],
         extra_link_args=['-fopenmp'])
 
         # extra_compile_args=['-O2'])
+
 
     return [extension]

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -44,5 +44,6 @@ User documentation
    boundaries
    cone_search
    interpolation
+   performance
    healpy_compat
    api

--- a/docs/performance.rst
+++ b/docs/performance.rst
@@ -1,13 +1,18 @@
 Performance and OpenMP
 ======================
 
+Measuring performance
+---------------------
+
 At this time, we have focused mostly on implementing functionality into the
 **astropy-healpix** package, and performance may therefore not be as good in
 some cases as the `healpy <https://github.com/healpy/healpy>`__ library. Once
 the API is stable, we will focus on improving performance. To get an idea of
 how the performance of the two packages compare, we have included some simple
 benchmarks that compare the healpy-compatible interface of **astropy-healpix**
-with healpy itself. These benchmarks are run with::
+with healpy itself. These benchmarks are run with:
+
+.. code-block:: bash
 
     $ python -m astropy_healpix.bench
     Running benchmarks...
@@ -33,9 +38,12 @@ not matter. For larger arrays, the difference is a factor of a few at most
 (without multi-threading). We will add more benchmarks over time to provide a
 more complete picture.
 
+Controlling the number of threads
+---------------------------------
+
 By default, OpenMP is used if available to parallelize many of the functions in
 **astropy-healpix** using multi-threading (the results above do). For example, when calling
-:meth:`HEALPix.healpix_to_skycoord` with an array of HEALPix indices, the array
+:meth:`~astropy_healpix.HEALPix.healpix_to_skycoord` with an array of HEALPix indices, the array
 is split up into multiple chunks which are distributed over threads. This should
 speed up the calculation by a factor depending on the number of available cores.
 
@@ -43,3 +51,25 @@ However, in some cases (such as in a shared computing environment) you may want
 to restrict this behavior to only ever use one core. You can control the number
 of threads used by setting the ``OMP_NUM_THREADS`` environment variable (set
 this to 1 to disable multi-threading).
+
+Handling compilers that don't support OpenMP
+--------------------------------------------
+
+If you are compiling the **astropy-healpix** package yourself, note that the
+default C compiler on MacOS X (clang) does not support OpenMP. You will need to
+explicitly set a different compiler - for example if you have GCC 6 installed
+via MacPorts, you can do:
+
+.. code-block:: bash
+
+    $ CC=gcc-mp-6 python setup.py install
+
+You can check the installation log for the following message which indicates
+that OpenMP is being used::
+
+    Compiling Cython extension with OpenMP support
+
+If your compiler does not support OpenMP, you will instead see the following
+message::
+
+    Cannot compile Cython extension with OpenMP, reverting to non-parallel code

--- a/docs/performance.rst
+++ b/docs/performance.rst
@@ -1,0 +1,45 @@
+Performance and OpenMP
+======================
+
+At this time, we have focused mostly on implementing functionality into the
+**astropy-healpix** package, and performance may therefore not be as good in
+some cases as the `healpy <https://github.com/healpy/healpy>`__ library. Once
+the API is stable, we will focus on improving performance. To get an idea of
+how the performance of the two packages compare, we have included some simple
+benchmarks that compare the healpy-compatible interface of **astropy-healpix**
+with healpy itself. These benchmarks are run with::
+
+    $ python -m astropy_healpix.bench
+    Running benchmarks...
+
+      fct    nest nside   size  time_healpy time_self   ratio
+    ------- ----- ----- ------- ----------- ---------- -------
+    pix2ang  True     1      10   0.0000081  0.0003575   43.91
+    pix2ang  True   128      10   0.0000082  0.0003471   42.52
+    pix2ang  True     1    1000   0.0000399  0.0004751   11.92
+    pix2ang  True   128    1000   0.0000345  0.0004575   13.28
+    pix2ang  True     1 1000000   0.0434032  0.1589150    3.66
+    pix2ang  True   128 1000000   0.0364285  0.1383810    3.80
+    pix2ang False     1      10   0.0000080  0.0004040   50.30
+    pix2ang False   128      10   0.0000082  0.0003322   40.63
+    pix2ang False     1    1000   0.0000400  0.0005005   12.50
+    pix2ang False   128    1000   0.0000548  0.0005045    9.21
+    pix2ang False     1 1000000   0.0342841  0.1429310    4.17
+    pix2ang False   128 1000000   0.0478645  0.1405270    2.94
+
+For small arrays, ``pix2ang`` in **astropy-healpix** performs worse, but in both
+caes the times are less than a millisecond, and such differences may therefore
+not matter. For larger arrays, the difference is a factor of a few at most
+(without multi-threading). We will add more benchmarks over time to provide a
+more complete picture.
+
+By default, OpenMP is used if available to parallelize many of the functions in
+**astropy-healpix** using multi-threading (the results above do). For example, when calling
+:meth:`HEALPix.healpix_to_skycoord` with an array of HEALPix indices, the array
+is split up into multiple chunks which are distributed over threads. This should
+speed up the calculation by a factor depending on the number of available cores.
+
+However, in some cases (such as in a shared computing environment) you may want
+to restrict this behavior to only ever use one core. You can control the number
+of threads used by setting the ``OMP_NUM_THREADS`` environment variable (set
+this to 1 to disable multi-threading).


### PR DESCRIPTION
This is a WIP, but it seems to work:

**Without OpenMP compilation flags**

```
  fct    nest nside   size  time_healpy time_self   ratio 
------- ----- ----- ------- ----------- ---------- -------
pix2ang  True     1      10   0.0000133  0.0004341   32.70
pix2ang  True   128      10   0.0000100  0.0003775   37.76
pix2ang  True     1    1000   0.0000521  0.0005752   11.04
pix2ang  True   128    1000   0.0000386  0.0006398   16.56
pix2ang  True     1 1000000   0.0364820  0.1662130    4.56
pix2ang  True   128 1000000   0.0316353  0.1336160    4.22
pix2ang False     1      10   0.0000151  0.0005352   35.45
pix2ang False   128      10   0.0000124  0.0004764   38.47
pix2ang False     1    1000   0.0000462  0.0005917   12.82
pix2ang False   128    1000   0.0000592  0.0006090   10.29
pix2ang False     1 1000000   0.0385104  0.1494491    3.88
pix2ang False   128 1000000   0.0479088  0.1596320    3.33
```

**With OpenMP compilation flags**

```
  fct    nest nside   size  time_healpy time_self   ratio 
------- ----- ----- ------- ----------- ---------- -------
pix2ang  True     1      10   0.0000089  0.0009528  107.47
pix2ang  True   128      10   0.0000092  0.0007257   78.79
pix2ang  True     1    1000   0.0000426  0.0005569   13.07
pix2ang  True   128    1000   0.0000374  0.0005880   15.74
pix2ang  True     1 1000000   0.0588481  0.1137643    1.93
pix2ang  True   128 1000000   0.0431057  0.1032697    2.40
pix2ang False     1      10   0.0000103  0.0009352   90.46
pix2ang False   128      10   0.0000121  0.0006978   57.57
pix2ang False     1    1000   0.0000415  0.0007433   17.90
pix2ang False   128    1000   0.0000564  0.0007113   12.62
pix2ang False     1 1000000   0.0411127  0.0812799    1.98
pix2ang False   128 1000000   0.0498509  0.0795615    1.60
```

However there is still some work to do here. With this I get some occasional test failures suggesting things aren't quite right:

```
    def test_interpolate_bilinear_skycoord(self):
        values = np.ones(12 * 256 ** 2) * 3
        coord = SkyCoord([1, 2, 3] * u.deg, [4, 3, 1] * u.deg, frame='fk4')
        result = self.pix.interpolate_bilinear_skycoord(coord, values)
        assert_allclose(result, [3, 3, 3])
    
        # Make sure that coordinate system is correctly taken into account
    
        values = np.arange(12 * 256 ** 2) * 3
        coord = SkyCoord([1, 2, 3] * u.deg, [4, 3, 1] * u.deg, frame='fk4')
    
        result1 = self.pix.interpolate_bilinear_skycoord(coord, values)
        result2 = self.pix.interpolate_bilinear_skycoord(coord.icrs, values)
    
>       assert_allclose(result1, result2)
E       AssertionError: 
E       Not equal to tolerance rtol=1e-07, atol=0
E       
E       (mismatch 33.33333333333333%)
E        x: array([ 1870655.960288,  1870303.535714,  1868938.874628])
E        y: array([ 1870683.430786,  1870303.535714,  1868938.874628])
```

(these are non-deterministic so maybe this has to do with variables being accessed/modified from different threads)

We also need to figure out how to determine if it's safe to put the -fopenmp flag or not (depends on the compiler). We might need a helper function that could live in astropy-helpers for that.

Closes https://github.com/astropy/astropy-healpix/issues/58