### PR TITLE
Add neighbors method to high-level class

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,9 @@
 
 - Use OpenMP to parallelize the Cython wrappers. [#59]
 
+- Renamed the ``healpix_neighbors`` function to ``neighbors`` and added
+  a wrapper to the high-level class. [#61]
+
 0.1 (2017-10-01)
 ================
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,7 +3,7 @@
 
 - Use OpenMP to parallelize the Cython wrappers. [#59]
 
-- Renamed the ``healpix_neighbors`` function to ``neighbors`` and added
+- Renamed the ``healpix_neighbours`` function to ``neighbours`` and added
   a wrapper to the high-level class. [#61]
 
 0.1 (2017-10-01)

--- a/astropy_healpix/core.py
+++ b/astropy_healpix/core.py
@@ -20,7 +20,7 @@ __all__ = [
     'lonlat_to_healpix',
     'healpix_to_lonlat',
     'interpolate_bilinear_lonlat',
-    'healpix_neighbors',
+    'neighbors',
 ]
 
 
@@ -344,7 +344,7 @@ def interpolate_bilinear_lonlat(lon, lat, values, order='ring'):
     """
     Interpolate values at specific longitudes/latitudes using bilinear interpolation
 
-    If a position does not have four neighbours, this currently returns NaN.
+    If a position does not have four neighbors, this currently returns NaN.
 
     Parameters
     ----------
@@ -386,9 +386,9 @@ def interpolate_bilinear_lonlat(lon, lat, values, order='ring'):
     return _restore_shape(result, shape=shape)
 
 
-def healpix_neighbors(healpix_index, nside, order='ring'):
+def neighbors(healpix_index, nside, order='ring'):
     """
-    Find all the HEALPix pixels that are the neighbours of a HEALPix pixel
+    Find all the HEALPix pixels that are the neighbors of a HEALPix pixel
 
     Parameters
     ----------
@@ -401,8 +401,8 @@ def healpix_neighbors(healpix_index, nside, order='ring'):
 
     Returns
     -------
-    neighbours : `~numpy.ndarray`
-        2-D array with shape (8, N) giving the neighbours starting SW and
+    neighbors : `~numpy.ndarray`
+        2-D array with shape (8, N) giving the neighbors starting SW and
         rotating clockwise.
     """
 
@@ -413,7 +413,7 @@ def healpix_neighbors(healpix_index, nside, order='ring'):
     _validate_nside(nside)
     order = _validate_order(order)
 
-    return core_cython.healpix_neighbors(healpix_index, nside, order)
+    return core_cython.neighbors(healpix_index, nside, order)
 
 
 def healpix_cone_search(lon, lat, radius, nside, order='ring'):

--- a/astropy_healpix/core.py
+++ b/astropy_healpix/core.py
@@ -393,7 +393,7 @@ def neighbors(healpix_index, nside, order='ring'):
     Parameters
     ----------
     healpix_index : `~numpy.ndarray`
-        1-D array of HEALPix pixels
+        Array of HEALPix pixels
     nside : int
         Number of pixels along the side of each of the 12 top-level HEALPix tiles
     order : { 'nested' | 'ring' }
@@ -401,19 +401,26 @@ def neighbors(healpix_index, nside, order='ring'):
 
     Returns
     -------
-    neighbors : `~numpy.ndarray`
-        2-D array with shape (8, N) giving the neighbors starting SW and
-        rotating clockwise.
+    neigh : `~numpy.ndarray`
+        Array giving the neighbors starting SW and rotating clockwise. This has
+        one extra dimension compared to ``healpix_index`` - the first dimension -
+        which is set to 8. For example if healpix_index has shape (2, 3),
+        ``neigh`` has shape (8, 2, 3).
     """
 
     healpix_index = np.asarray(healpix_index, dtype=np.int64)
     nside = int(nside)
 
+    shape = np.shape(healpix_index)
+
+    healpix_index = healpix_index.ravel()
+
     _validate_healpix_index('healpix_index', healpix_index, nside)
     _validate_nside(nside)
     order = _validate_order(order)
 
-    return core_cython.neighbors(healpix_index, nside, order)
+    neigh = core_cython.neighbors(healpix_index, nside, order)
+    return _restore_shape(neigh, shape=(8,) + shape)
 
 
 def healpix_cone_search(lon, lat, radius, nside, order='ring'):

--- a/astropy_healpix/core.py
+++ b/astropy_healpix/core.py
@@ -20,7 +20,7 @@ __all__ = [
     'lonlat_to_healpix',
     'healpix_to_lonlat',
     'interpolate_bilinear_lonlat',
-    'neighbors',
+    'neighbours',
 ]
 
 
@@ -344,7 +344,7 @@ def interpolate_bilinear_lonlat(lon, lat, values, order='ring'):
     """
     Interpolate values at specific longitudes/latitudes using bilinear interpolation
 
-    If a position does not have four neighbors, this currently returns NaN.
+    If a position does not have four neighbours, this currently returns NaN.
 
     Parameters
     ----------
@@ -386,9 +386,9 @@ def interpolate_bilinear_lonlat(lon, lat, values, order='ring'):
     return _restore_shape(result, shape=shape)
 
 
-def neighbors(healpix_index, nside, order='ring'):
+def neighbours(healpix_index, nside, order='ring'):
     """
-    Find all the HEALPix pixels that are the neighbors of a HEALPix pixel
+    Find all the HEALPix pixels that are the neighbours of a HEALPix pixel
 
     Parameters
     ----------
@@ -402,7 +402,7 @@ def neighbors(healpix_index, nside, order='ring'):
     Returns
     -------
     neigh : `~numpy.ndarray`
-        Array giving the neighbors starting SW and rotating clockwise. This has
+        Array giving the neighbours starting SW and rotating clockwise. This has
         one extra dimension compared to ``healpix_index`` - the first dimension -
         which is set to 8. For example if healpix_index has shape (2, 3),
         ``neigh`` has shape (8, 2, 3).
@@ -419,7 +419,7 @@ def neighbors(healpix_index, nside, order='ring'):
     _validate_nside(nside)
     order = _validate_order(order)
 
-    neigh = core_cython.neighbors(healpix_index, nside, order)
+    neigh = core_cython.neighbours(healpix_index, nside, order)
     return _restore_shape(neigh, shape=(8,) + shape)
 
 

--- a/astropy_healpix/core_cython.pyx
+++ b/astropy_healpix/core_cython.pyx
@@ -290,7 +290,7 @@ def interpolate_bilinear_lonlat(np.ndarray[double_t, ndim=1, mode="c"] lon,
     """
     Interpolate values at specific longitudes/latitudes using bilinear interpolation
 
-    If a position does not have four neighbours, this currently returns NaN.
+    If a position does not have four neighbors, this currently returns NaN.
 
     Parameters
     ----------
@@ -446,10 +446,10 @@ def interpolate_bilinear_lonlat(np.ndarray[double_t, ndim=1, mode="c"] lon,
 
 
 @cython.boundscheck(False)
-def healpix_neighbors(np.ndarray[int64_t, ndim=1, mode="c"] healpix_index,
-                       int nside, str order):
+def neighbors(np.ndarray[int64_t, ndim=1, mode="c"] healpix_index,
+              int nside, str order):
     """
-    Find all the HEALPix pixels that are the neighbours of a HEALPix pixel
+    Find all the HEALPix pixels that are the neighbors of a HEALPix pixel
 
     Parameters
     ----------
@@ -462,8 +462,8 @@ def healpix_neighbors(np.ndarray[int64_t, ndim=1, mode="c"] healpix_index,
 
     Returns
     -------
-    neighbours : `~numpy.ndarray`
-        2-D array with shape (8, N) giving the neighbours starting SW and
+    neighbors : `~numpy.ndarray`
+        2-D array with shape (8, N) giving the neighbors starting SW and
         rotating clockwise.
     """
 
@@ -537,7 +537,7 @@ def healpix_neighbors(np.ndarray[int64_t, ndim=1, mode="c"] healpix_index,
 
         free(neighbours_indiv)
 
-    return neighbours
+    return neighbors
 
 
 @cython.boundscheck(False)

--- a/astropy_healpix/core_cython.pyx
+++ b/astropy_healpix/core_cython.pyx
@@ -290,7 +290,7 @@ def interpolate_bilinear_lonlat(np.ndarray[double_t, ndim=1, mode="c"] lon,
     """
     Interpolate values at specific longitudes/latitudes using bilinear interpolation
 
-    If a position does not have four neighbors, this currently returns NaN.
+    If a position does not have four neighbours, this currently returns NaN.
 
     Parameters
     ----------
@@ -446,10 +446,10 @@ def interpolate_bilinear_lonlat(np.ndarray[double_t, ndim=1, mode="c"] lon,
 
 
 @cython.boundscheck(False)
-def neighbors(np.ndarray[int64_t, ndim=1, mode="c"] healpix_index,
-              int nside, str order):
+def neighbours(np.ndarray[int64_t, ndim=1, mode="c"] healpix_index,
+               int nside, str order):
     """
-    Find all the HEALPix pixels that are the neighbors of a HEALPix pixel
+    Find all the HEALPix pixels that are the neighbours of a HEALPix pixel
 
     Parameters
     ----------
@@ -462,8 +462,8 @@ def neighbors(np.ndarray[int64_t, ndim=1, mode="c"] healpix_index,
 
     Returns
     -------
-    neighbors : `~numpy.ndarray`
-        2-D array with shape (8, N) giving the neighbors starting SW and
+    neighbours : `~numpy.ndarray`
+        2-D array with shape (8, N) giving the neighbours starting SW and
         rotating clockwise.
     """
 
@@ -537,7 +537,7 @@ def neighbors(np.ndarray[int64_t, ndim=1, mode="c"] healpix_index,
 
         free(neighbours_indiv)
 
-    return neighbors
+    return neighbours
 
 
 @cython.boundscheck(False)

--- a/astropy_healpix/high_level.py
+++ b/astropy_healpix/high_level.py
@@ -9,7 +9,7 @@ from astropy.coordinates.representation import UnitSphericalRepresentation
 from .core import (nside_to_pixel_area, nside_to_pixel_resolution,
                    nside_to_npix, healpix_to_lonlat, lonlat_to_healpix,
                    interpolate_bilinear_lonlat, ring_to_nested, nested_to_ring,
-                   healpix_cone_search, boundaries_lonlat)
+                   healpix_cone_search, boundaries_lonlat, healpix_neighbors)
 
 __all__ = ['HEALPix']
 
@@ -226,6 +226,23 @@ class HEALPix(object):
             size ``4 * step``.
         """
         return boundaries_lonlat(healpix_index, step, self.nside, order=self.order)
+
+    def healpix_neighbors(self, healpix_index):
+        """
+        Find all the HEALPix pixels that are the neighbours of a HEALPix pixel
+
+        Parameters
+        ----------
+        healpix_index : `~numpy.ndarray`
+            1-D array of HEALPix pixels
+
+        Returns
+        -------
+        neighbours : `~numpy.ndarray`
+            2-D array with shape (8, N) giving the neighbours starting SW and
+            rotating clockwise.
+        """
+        return healpix_neighbors(healpix_index, self.nside, order=self.order)
 
     def healpix_to_skycoord(self, healpix_index, dx=None, dy=None):
         """

--- a/astropy_healpix/high_level.py
+++ b/astropy_healpix/high_level.py
@@ -9,7 +9,7 @@ from astropy.coordinates.representation import UnitSphericalRepresentation
 from .core import (nside_to_pixel_area, nside_to_pixel_resolution,
                    nside_to_npix, healpix_to_lonlat, lonlat_to_healpix,
                    interpolate_bilinear_lonlat, ring_to_nested, nested_to_ring,
-                   healpix_cone_search, boundaries_lonlat, neighbors)
+                   healpix_cone_search, boundaries_lonlat, neighbours)
 
 __all__ = ['HEALPix']
 
@@ -156,7 +156,7 @@ class HEALPix(object):
         """
         Interpolate values at specific longitudes/latitudes using bilinear interpolation
 
-        If a position does not have four neighbors, this currently returns NaN.
+        If a position does not have four neighbours, this currently returns NaN.
 
         Parameters
         ----------
@@ -227,9 +227,9 @@ class HEALPix(object):
         """
         return boundaries_lonlat(healpix_index, step, self.nside, order=self.order)
 
-    def neighbors(self, healpix_index):
+    def neighbours(self, healpix_index):
         """
-        Find all the HEALPix pixels that are the neighbors of a HEALPix pixel
+        Find all the HEALPix pixels that are the neighbours of a HEALPix pixel
 
         Parameters
         ----------
@@ -239,12 +239,12 @@ class HEALPix(object):
         Returns
         -------
         neigh : `~numpy.ndarray`
-            Array giving the neighbors starting SW and rotating clockwise. This has
+            Array giving the neighbours starting SW and rotating clockwise. This has
             one extra dimension compared to ``healpix_index`` - the first dimension -
             which is set to 8. For example if healpix_index has shape (2, 3),
             ``neigh`` has shape (8, 2, 3).
         """
-        return neighbors(healpix_index, self.nside, order=self.order)
+        return neighbours(healpix_index, self.nside, order=self.order)
 
     def healpix_to_skycoord(self, healpix_index, dx=None, dy=None):
         """
@@ -311,7 +311,7 @@ class HEALPix(object):
         """
         Interpolate values at specific celestial coordinates using bilinear interpolation.
 
-        If a position does not have four neighbors, this currently returns NaN.
+        If a position does not have four neighbours, this currently returns NaN.
 
         Note that this method requires that a celestial frame was specified when
         initializing HEALPix. If you don't know or need the celestial frame, you

--- a/astropy_healpix/high_level.py
+++ b/astropy_healpix/high_level.py
@@ -234,13 +234,15 @@ class HEALPix(object):
         Parameters
         ----------
         healpix_index : `~numpy.ndarray`
-            1-D array of HEALPix pixels
+            Array of HEALPix pixels
 
         Returns
         -------
-        neighbors : `~numpy.ndarray`
-            2-D array with shape (8, N) giving the neighbors starting SW and
-            rotating clockwise.
+        neigh : `~numpy.ndarray`
+            Array giving the neighbors starting SW and rotating clockwise. This has
+            one extra dimension compared to ``healpix_index`` - the first dimension -
+            which is set to 8. For example if healpix_index has shape (2, 3),
+            ``neigh`` has shape (8, 2, 3).
         """
         return neighbors(healpix_index, self.nside, order=self.order)
 

--- a/astropy_healpix/high_level.py
+++ b/astropy_healpix/high_level.py
@@ -9,7 +9,7 @@ from astropy.coordinates.representation import UnitSphericalRepresentation
 from .core import (nside_to_pixel_area, nside_to_pixel_resolution,
                    nside_to_npix, healpix_to_lonlat, lonlat_to_healpix,
                    interpolate_bilinear_lonlat, ring_to_nested, nested_to_ring,
-                   healpix_cone_search, boundaries_lonlat, healpix_neighbors)
+                   healpix_cone_search, boundaries_lonlat, neighbors)
 
 __all__ = ['HEALPix']
 
@@ -156,7 +156,7 @@ class HEALPix(object):
         """
         Interpolate values at specific longitudes/latitudes using bilinear interpolation
 
-        If a position does not have four neighbours, this currently returns NaN.
+        If a position does not have four neighbors, this currently returns NaN.
 
         Parameters
         ----------
@@ -227,9 +227,9 @@ class HEALPix(object):
         """
         return boundaries_lonlat(healpix_index, step, self.nside, order=self.order)
 
-    def healpix_neighbors(self, healpix_index):
+    def neighbors(self, healpix_index):
         """
-        Find all the HEALPix pixels that are the neighbours of a HEALPix pixel
+        Find all the HEALPix pixels that are the neighbors of a HEALPix pixel
 
         Parameters
         ----------
@@ -238,11 +238,11 @@ class HEALPix(object):
 
         Returns
         -------
-        neighbours : `~numpy.ndarray`
-            2-D array with shape (8, N) giving the neighbours starting SW and
+        neighbors : `~numpy.ndarray`
+            2-D array with shape (8, N) giving the neighbors starting SW and
             rotating clockwise.
         """
-        return healpix_neighbors(healpix_index, self.nside, order=self.order)
+        return neighbors(healpix_index, self.nside, order=self.order)
 
     def healpix_to_skycoord(self, healpix_index, dx=None, dy=None):
         """
@@ -309,7 +309,7 @@ class HEALPix(object):
         """
         Interpolate values at specific celestial coordinates using bilinear interpolation.
 
-        If a position does not have four neighbours, this currently returns NaN.
+        If a position does not have four neighbors, this currently returns NaN.
 
         Note that this method requires that a celestial frame was specified when
         initializing HEALPix. If you don't know or need the celestial frame, you

--- a/astropy_healpix/tests/test_core.py
+++ b/astropy_healpix/tests/test_core.py
@@ -16,7 +16,7 @@ from astropy.coordinates import Longitude, Latitude
 from ..core import (nside_to_pixel_area, nside_to_pixel_resolution,
                     nside_to_npix, npix_to_nside, healpix_to_lonlat,
                     lonlat_to_healpix, interpolate_bilinear_lonlat,
-                    healpix_neighbors, healpix_cone_search, boundaries_lonlat,
+                    neighbors, healpix_cone_search, boundaries_lonlat,
                     level_to_nside, nested_to_ring, ring_to_nested)
 
 
@@ -195,8 +195,8 @@ def test_interpolate_bilinear_lonlat_shape():
 
 
 @pytest.mark.parametrize('order', ['nested', 'ring'])
-def test_healpix_neighbors(order):
-    neighbours = healpix_neighbors([1, 2, 3], 4, order=order)
+def test_neighbors(order):
+    neigh = neighbors([1, 2, 3], 4, order=order)
 
     if order == 'nested':
         expected = [[0, 71, 2],
@@ -218,20 +218,20 @@ def test_healpix_neighbors(order):
                     [7, 9, 11],
                     [16, 19, 22]]
 
-    assert_equal(neighbours, expected)
+    assert_equal(neigh, expected)
 
 
-def test_healpix_neighbors_invalid():
+def test_neighbors_invalid():
     with pytest.raises(ValueError) as exc:
-        healpix_neighbors([-1, 2, 3], 4)
+        neighbors([-1, 2, 3], 4)
     assert exc.value.args[0] == 'healpix_index must be in the range [0:192]'
 
     with pytest.raises(ValueError) as exc:
-        healpix_neighbors([1, 2, 3], 5)
+        neighbors([1, 2, 3], 5)
     assert exc.value.args[0] == 'nside must be a power of two'
 
     with pytest.raises(ValueError) as exc:
-        healpix_neighbors([1, 2, 3], 4, order='banana')
+        neighbors([1, 2, 3], 4, order='banana')
     assert exc.value.args[0] == "order must be 'nested' or 'ring'"
 
 

--- a/astropy_healpix/tests/test_core.py
+++ b/astropy_healpix/tests/test_core.py
@@ -16,7 +16,7 @@ from astropy.coordinates import Longitude, Latitude
 from ..core import (nside_to_pixel_area, nside_to_pixel_resolution,
                     nside_to_npix, npix_to_nside, healpix_to_lonlat,
                     lonlat_to_healpix, interpolate_bilinear_lonlat,
-                    neighbors, healpix_cone_search, boundaries_lonlat,
+                    neighbours, healpix_cone_search, boundaries_lonlat,
                     level_to_nside, nested_to_ring, ring_to_nested)
 
 
@@ -195,8 +195,8 @@ def test_interpolate_bilinear_lonlat_shape():
 
 
 @pytest.mark.parametrize('order', ['nested', 'ring'])
-def test_neighbors(order):
-    neigh = neighbors([1, 2, 3], 4, order=order)
+def test_neighbours(order):
+    neigh = neighbours([1, 2, 3], 4, order=order)
 
     if order == 'nested':
         expected = [[0, 71, 2],
@@ -221,22 +221,22 @@ def test_neighbors(order):
     assert_equal(neigh, expected)
 
 
-def test_neighbors_invalid():
+def test_neighbours_invalid():
     with pytest.raises(ValueError) as exc:
-        neighbors([-1, 2, 3], 4)
+        neighbours([-1, 2, 3], 4)
     assert exc.value.args[0] == 'healpix_index must be in the range [0:192]'
 
     with pytest.raises(ValueError) as exc:
-        neighbors([1, 2, 3], 5)
+        neighbours([1, 2, 3], 5)
     assert exc.value.args[0] == 'nside must be a power of two'
 
     with pytest.raises(ValueError) as exc:
-        neighbors([1, 2, 3], 4, order='banana')
+        neighbours([1, 2, 3], 4, order='banana')
     assert exc.value.args[0] == "order must be 'nested' or 'ring'"
 
 
-def test_neighbors_shape():
-    neigh = neighbors([[1, 2, 3], [2, 3, 4]], 4)
+def test_neighbours_shape():
+    neigh = neighbours([[1, 2, 3], [2, 3, 4]], 4)
     assert neigh.shape == (8, 2, 3)
 
 

--- a/astropy_healpix/tests/test_core.py
+++ b/astropy_healpix/tests/test_core.py
@@ -235,6 +235,11 @@ def test_neighbors_invalid():
     assert exc.value.args[0] == "order must be 'nested' or 'ring'"
 
 
+def test_neighbors_shape():
+    neigh = neighbors([[1, 2, 3], [2, 3, 4]], 4)
+    assert neigh.shape == (8, 2, 3)
+
+
 @pytest.mark.parametrize('order', ['nested', 'ring'])
 def test_healpix_cone_search(order):
     indices = healpix_cone_search(10 * u.deg, 20 * u.deg, 1 * u.deg,

--- a/astropy_healpix/tests/test_core_cython.py
+++ b/astropy_healpix/tests/test_core_cython.py
@@ -75,12 +75,12 @@ def test_roundtrip_nested_ring(nside_power, capfd):
 
 
 @pytest.mark.parametrize(('order', 'nside_power'), product(ORDERS, NSIDE_POWERS))
-def test_healpix_neighbors(order, nside_power, capfd):
+def test_neighbors(order, nside_power, capfd):
     # This just makes sure things run, but doesn't check the validity of result
     nside = 2 ** nside_power
     index = get_test_indices(nside)
-    neighbours = core_cython.healpix_neighbors(index, nside, order)
-    assert np.all(neighbours >= -1) and np.all(neighbours < 12 * nside ** 2)
+    neighbors = core_cython.neighbors(index, nside, order)
+    assert np.all(neighbors >= -1) and np.all(neighbors < 12 * nside ** 2)
     out, err = capfd.readouterr()
     assert out == "" and err == ""
 

--- a/astropy_healpix/tests/test_core_cython.py
+++ b/astropy_healpix/tests/test_core_cython.py
@@ -75,12 +75,12 @@ def test_roundtrip_nested_ring(nside_power, capfd):
 
 
 @pytest.mark.parametrize(('order', 'nside_power'), product(ORDERS, NSIDE_POWERS))
-def test_neighbors(order, nside_power, capfd):
+def test_neighbours(order, nside_power, capfd):
     # This just makes sure things run, but doesn't check the validity of result
     nside = 2 ** nside_power
     index = get_test_indices(nside)
-    neighbors = core_cython.neighbors(index, nside, order)
-    assert np.all(neighbors >= -1) and np.all(neighbors < 12 * nside ** 2)
+    neighbours = core_cython.neighbours(index, nside, order)
+    assert np.all(neighbours >= -1) and np.all(neighbours < 12 * nside ** 2)
     out, err = capfd.readouterr()
     assert out == "" and err == ""
 

--- a/astropy_healpix/tests/test_high_level.py
+++ b/astropy_healpix/tests/test_high_level.py
@@ -92,9 +92,9 @@ class TestHEALPix:
         assert lon.shape == (3, 16)
         assert lat.shape == (3, 16)
 
-    def test_healpix_neighbors(self):
-        neighbors = self.pix.healpix_neighbors([10, 20, 30])
-        assert neighbors.shape == (8, 3)
+    def test_neighbors(self):
+        neigh = self.pix.neighbors([10, 20, 30])
+        assert neigh.shape == (8, 3)
 
 
 class TestCelestialHEALPix:

--- a/astropy_healpix/tests/test_high_level.py
+++ b/astropy_healpix/tests/test_high_level.py
@@ -92,8 +92,8 @@ class TestHEALPix:
         assert lon.shape == (3, 16)
         assert lat.shape == (3, 16)
 
-    def test_neighbors(self):
-        neigh = self.pix.neighbors([10, 20, 30])
+    def test_neighbours(self):
+        neigh = self.pix.neighbours([10, 20, 30])
         assert neigh.shape == (8, 3)
 
 

--- a/astropy_healpix/tests/test_high_level.py
+++ b/astropy_healpix/tests/test_high_level.py
@@ -92,6 +92,10 @@ class TestHEALPix:
         assert lon.shape == (3, 16)
         assert lat.shape == (3, 16)
 
+    def test_healpix_neighbors(self):
+        neighbors = self.pix.healpix_neighbors([10, 20, 30])
+        assert neighbors.shape == (8, 3)
+
 
 class TestCelestialHEALPix:
 


### PR DESCRIPTION
Fixes #52 - also renames the function and method to simply 'neighbors' since the ``healpix_`` is not meaningful here (we don't have it for e.g interpolate or cone search)

Also fixes #53