### PR TITLE
Expand benchmarks

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,8 @@
 0.2 (unreleased)
 ================
 
+- Expand benchmarks to include ang2pix, nest2ring and ring2nest. [#62]
+
 - Use OpenMP to parallelize the Cython wrappers. [#59]
 
 0.1 (2017-10-01)


### PR DESCRIPTION
This now includes ang2pix, nest2ring and ring2nest. Results with OpenMP:

```
$ OMP_NUM_THREADS=4 python -m astropy_healpix.bench
Running benchmarks...

 function  nest nside   size   time_healpy time_self   ratio 
--------- ----- ----- -------- ----------- ---------- -------
  pix2ang  True     1       10   0.0000195  0.0006311   32.38
  pix2ang  True   128       10   0.0000198  0.0005038   25.41
  pix2ang  True     1     1000   0.0000767  0.0006432    8.38
  pix2ang  True   128     1000   0.0000792  0.0005654    7.14
  pix2ang  True     1  1000000   0.0649799  0.0659915    1.02
  pix2ang  True   128  1000000   0.0645760  0.0913511    1.41
  pix2ang  True     1 10000000   0.6714709  0.7274139    1.08
  pix2ang  True   128 10000000   0.6703229  0.8520050    1.27
  pix2ang False     1       10   0.0000263  0.0007929   30.11
  pix2ang False   128       10   0.0000255  0.0007503   29.48
  pix2ang False     1     1000   0.0001052  0.0008894    8.45
  pix2ang False   128     1000   0.0000692  0.0008082   11.67
  pix2ang False     1  1000000   0.0586342  0.0739859    1.26
  pix2ang False   128  1000000   0.0534918  0.1012111    1.89
  pix2ang False     1 10000000   0.6298459  0.6816821    1.08
  pix2ang False   128 10000000   0.5298700  0.8358471    1.58
  ang2pix  True     1       10   0.0000199  0.0001946    9.79
  ang2pix  True   128       10   0.0000204  0.0002056   10.07
  ang2pix  True     1     1000   0.0000780  0.0002564    3.29
  ang2pix  True   128     1000   0.0000740  0.0003053    4.12
  ang2pix  True     1  1000000   0.0662609  0.0860509    1.30
  ang2pix  True   128  1000000   0.0662438  0.0903710    1.36
  ang2pix  True     1 10000000   0.8882880  1.0137250    1.14
  ang2pix  True   128 10000000   0.6873419  1.0235200    1.49
  ang2pix False     1       10   0.0000214  0.0001938    9.04
  ang2pix False   128       10   0.0000181  0.0001869   10.31
  ang2pix False     1     1000   0.0000713  0.0003108    4.36
  ang2pix False   128     1000   0.0000631  0.0002797    4.43
  ang2pix False     1  1000000   0.0612744  0.0844119    1.38
  ang2pix False   128  1000000   0.0525504  0.0859808    1.64
  ang2pix False     1 10000000   0.5981770  0.8709679    1.46
  ang2pix False   128 10000000   0.5335019  0.9492381    1.78
nest2ring    --     1       10   0.0000195  0.0001122    5.75
nest2ring    --   128       10   0.0000203  0.0001038    5.11
nest2ring    --     1     1000   0.0000811  0.0001013    1.25
nest2ring    --   128     1000   0.0000631  0.0001252    1.98
nest2ring    --     1  1000000   0.0596820  0.0245368    0.41
nest2ring    --   128  1000000   0.0546553  0.0303620    0.56
nest2ring    --     1 10000000   0.6113091  0.2222869    0.36
nest2ring    --   128 10000000   0.5426979  0.2797091    0.52
ring2nest    --     1       10   0.0000191  0.0001025    5.37
ring2nest    --   128       10   0.0000194  0.0001056    5.44
ring2nest    --     1     1000   0.0000714  0.0001094    1.53
ring2nest    --   128     1000   0.0000673  0.0001279    1.90
ring2nest    --     1  1000000   0.0614112  0.0278640    0.45
ring2nest    --   128  1000000   0.0540822  0.0353133    0.65
ring2nest    --     1 10000000   0.6166291  0.2841570    0.46
ring2nest    --   128 10000000   0.5240710  0.3181159    0.61
```

This also fixes the pix2ang benchmark which before was only checking the performance when converting the '0' index, which was misleading since performance depends quite a lot on where on the sphere one is looking.