### PR TITLE
Add resolution to order helper function

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 0.3 (unreleased)
 ================
 
-- No changes yet.
+- Add ``pixel_resolution_to_nside`` function. [#31]
 
 0.2 (2017-10-15)
 ================

--- a/astropy_healpix/core.py
+++ b/astropy_healpix/core.py
@@ -7,7 +7,7 @@ import math
 import numpy as np
 
 from astropy import units as u
-from astropy.coordinates import Longitude, Latitude
+from astropy.coordinates import Longitude, Latitude, Angle
 
 from . import core_cython
 from .core_cython import _validate_order
@@ -15,6 +15,7 @@ from .core_cython import _validate_order
 __all__ = [
     'nside_to_pixel_area',
     'nside_to_pixel_resolution',
+    'pixel_resolution_to_nside',
     'nside_to_npix',
     'npix_to_nside',
     'lonlat_to_healpix',
@@ -51,7 +52,7 @@ def _validate_offset(label, offset):
 
 
 def _validate_level(level):
-    if level < 0:
+    if np.any(level < 0):
         raise ValueError('level must be positive')
 
 
@@ -116,10 +117,70 @@ def nside_to_pixel_resolution(nside):
     -------
     resolution : :class:`~astropy.units.Quantity`
         The resolution of the HEALPix pixels
+
+    See also
+    --------
+    pixel_resolution_to_nside
     """
     nside = np.asanyarray(nside, dtype=np.int64)
     _validate_nside(nside)
     return (nside_to_pixel_area(nside) ** 0.5).to(u.arcmin)
+
+
+def pixel_resolution_to_nside(resolution, round='nearest'):
+    """Find closest HEALPix nside for a given angular resolution.
+
+    This function is the inverse of `nside_to_pixel_resolution`,
+    for the default rounding scheme of ``round='nearest'``.
+
+    If you choose ``round='up'``, you'll get HEALPix pixels that
+    have at least the requested resolution (usually a bit better
+    due to rounding).
+
+    Pixel resolution is defined as square root of pixel area.
+
+    Parameters
+    ----------
+    resolution : `~astropy.units.Quantity`
+        Angular resolution
+    round : {'up', 'nearest', 'down'}
+        Which way to round
+
+    Returns
+    -------
+    nside : int
+        The number of pixels on the side of one of the 12 'top-level' HEALPix tiles.
+        Always a power of 2.
+
+    Examples
+    --------
+    >>> from astropy_healpix import pixel_resolution_to_nside
+    >>> pixel_resolution_to_nside('13 arcmin')
+    256
+    >>> pixel_resolution_to_nside('13 arcmin', round='up')
+    512
+    """
+    resolution = Angle(resolution).radian
+    pixel_area = resolution * resolution
+    npix = 4 * math.pi / pixel_area
+    nside = np.sqrt(npix / 12)
+
+    # Now we have to round to the closest ``nside``
+    # Since ``nside`` must be a power of two,
+    # we first compute the corresponding ``level = log2(nside)`
+    # round the level and then go back to nside
+    level = np.log2(nside)
+
+    if round == 'up':
+        level = np.array(level, dtype=int) + 1
+    elif round == 'nearest':
+        level = np.array(level + 0.5, dtype=int)
+    elif round == 'down':
+        level = np.array(level, dtype=int)
+    else:
+        raise ValueError('Invalid value for round: {!r}'.format(round))
+
+    return level_to_nside(np.clip(level, 0, None))
 
 
 def nside_to_npix(nside):

--- a/astropy_healpix/tests/test_core.py
+++ b/astropy_healpix/tests/test_core.py
@@ -43,13 +43,13 @@ def test_nside_to_pixel_resolution():
 def test_pixel_resolution_to_nside():
 
     # Check the different rounding options
-    nside = pixel_resolution_to_nside('13 arcmin', round='nearest')
+    nside = pixel_resolution_to_nside(13 * u.arcmin, round='nearest')
     assert nside == 256
 
-    nside = pixel_resolution_to_nside('13 arcmin', round='up')
+    nside = pixel_resolution_to_nside(13 * u.arcmin, round='up')
     assert nside == 512
 
-    nside = pixel_resolution_to_nside('13 arcmin', round='down')
+    nside = pixel_resolution_to_nside(13 * u.arcmin, round='down')
     assert nside == 256
 
     # Check that it works with arrays
@@ -57,12 +57,12 @@ def test_pixel_resolution_to_nside():
     assert_equal(nside, [1, 8, 65536])
 
     with pytest.raises(ValueError) as exc:
-        pixel_resolution_to_nside('13 arcmin', round='peaches')
+        pixel_resolution_to_nside(13 * u.arcmin, round='peaches')
     assert exc.value.args[0] == "Invalid value for round: 'peaches'"
 
-    with pytest.raises(TypeError) as exc:
+    with pytest.raises(AttributeError) as exc:
         pixel_resolution_to_nside(13)
-    assert 'no unit was given' in exc.value.args[0]
+    assert exc.value.args[0] == "'int' object has no attribute 'to'"
 
 
 def test_nside_to_npix():


### PR DESCRIPTION
Healpy has an `nside2resol` function:
http://healpy.readthedocs.io/en/latest/generated/healpy.pixelfunc.nside2resol.html

Both in Gammapy and the hips package we needed the reverse, a function that gives the closest nside or order for a given resolution.
* In Gammapy @woodmd implemented a `get_nside_from_pixel_size` function: https://github.com/gammapy/gammapy/blob/ae9067dad064aef16eb72e41cee425bf182b7229/gammapy/maps/hpx.py#L154
* In hipspy we added a `hips_order_for_pixel_resolution` function which is similar:
https://github.com/hipspy/hips/blob/2476251bea200d7221269b44772cb31660751730/hips/utils/healpix.py#L134


@astrofrog - Does it exist here already? Would it be welcome?

@astrofrog @woodmd - Can you recommend a signature? (i.e. return `nside` or `resolution`, but also if default should be to round up or down, or maybe even force the user to specify a `round={'down', 'up', 'float'}` or something like this by default?

Once I know what we want, I can add this in the coming days (with good docstring and tests).