### PR TITLE
WIP: Reimplement core_cython routines as ufuncs

### DIFF
--- a/astropy_healpix/high_level.py
+++ b/astropy_healpix/high_level.py
@@ -73,7 +73,7 @@ class HEALPix(object):
         """
         return nside_to_npix(self.nside)
 
-    def healpix_to_lonlat(self, healpix_index, dx=None, dy=None):
+    def healpix_to_lonlat(self, healpix_index, dx=0.5, dy=0.5):
         """
         Convert HEALPix indices (optionally with offsets) to longitudes/latitudes
 
@@ -269,7 +269,7 @@ class HEALPix(object):
         """
         return neighbours(healpix_index, self.nside, order=self.order)
 
-    def healpix_to_skycoord(self, healpix_index, dx=None, dy=None):
+    def healpix_to_skycoord(self, healpix_index, dx=0.5, dy=0.5):
         """
         Convert HEALPix indices (optionally with offsets) to celestial coordinates.
 


### PR DESCRIPTION
This eliminates the need for much of the explicit broadasting and type checking.

At the moment, the patch just implements `healpix_to_lonlat_ring`. I'd like to ask for feedback on the basic approach before undertaking conversion of the other functions.

Fixes #72.