### PR TITLE
WIP: interpolate_bilinear_lonlat raises IndexError for nans

### DIFF
--- a/astropy_healpix/tests/test_core.py
+++ b/astropy_healpix/tests/test_core.py
@@ -242,6 +242,13 @@ def test_interpolate_bilinear_invalid():
                                     values, order='banana')
     assert exc.value.args[0] == "order must be 'nested' or 'ring'"
 
+    result = interpolate_bilinear_lonlat([0, np.nan] * u.deg,
+                                         [0, np.nan] * u.deg, values,
+                                         order='nested')
+    assert result.shape == (2,)
+    assert result[0] == 1
+    assert np.isnan(result[1])
+
 
 def test_interpolate_bilinear_lonlat_shape():
 


### PR DESCRIPTION
The `interpolate_bilinear_lonlat` function raises an IndexError if the longitude or latitude that are passed to it are nans. This is because some or all of the indices returned by `bilinear_interpolation_weights` are negative in order to indicate failure, which may not necessarily be valid indices.

This breaks the HEALPix functions in the `reproject` package.

**Important note**: do not merge this pull request yet. This is a work in progress. It illustrates the bug by adding a unit test, but does not fix the bug.