### PR TITLE
Make Numpy docstring output reproducible across Numpy versions

### DIFF
--- a/astropy_healpix/conftest.py
+++ b/astropy_healpix/conftest.py
@@ -48,3 +48,14 @@ try:
     TESTED_VERSIONS[packagename] = version
 except NameError:   # Needed to support Astropy <= 1.0.0
     pass
+
+def pytest_configure():
+    """Set the Numpy print style to a fixed version to make doctest outputs
+    reproducible."""
+    import numpy as np
+    try:
+        np.set_printoptions(legacy='1.13')
+    except TypeError:
+        # On older versions of Numpy, the unrecognized 'legacy' option will
+        # raise a TypeError.
+        pass

--- a/docs/healpy_compat.rst
+++ b/docs/healpy_compat.rst
@@ -1,6 +1,3 @@
-.. doctest-skip-all
-
-
 Healpy-compatible interface
 ===========================
 
@@ -19,7 +16,7 @@ convention)::
 
   >>> from astropy_healpix.healpy import pix2ang
   >>> pix2ang(16, [100, 120])
-  (array([0.35914432, 0.41113786]), array([3.70259134, 1.6689711 ]))
+  (array([ 0.35914432,  0.41113786]), array([ 3.70259134,  1.6689711 ]))
 
 which agrees exactly with the healpy function::
 
@@ -27,7 +24,7 @@ which agrees exactly with the healpy function::
 
   >>> from healpy import pix2ang
   >>> pix2ang(16, [100, 120])
-  (array([0.35914432, 0.41113786]), array([3.70259134, 1.6689711 ]))
+  (array([ 0.35914432,  0.41113786]), array([ 3.70259134,  1.6689711 ]))
 
 Migrate
 -------


### PR DESCRIPTION
Numpy's string representation of arrays changed significantly from 1.13 to 1.14. See the Numpy [changelog]. We have to set the legacy representation mode for our doctests to be reproducible across both old and new versions of Numpy.

[changelog]: https://docs.scipy.org/doc/numpy-1.14.0/release.html#many-changes-to-array-printing-disableable-with-the-new-legacy-printing-mode