### PR TITLE
Added failing example for test_pix2ang

### DIFF
--- a/astropy_healpix/tests/test_healpy.py
+++ b/astropy_healpix/tests/test_healpy.py
@@ -100,6 +100,7 @@ def test_pix2ang_shape():
        frac=floats(0, 1, allow_nan=False, allow_infinity=False).filter(lambda x: x < 1))
 @settings(max_examples=2000, derandomize=True)
 @example(nside_pow=29, frac=0.1666666694606345, nest=False, lonlat=False)
+@example(nside_pow=27, frac=2./3., nest=True, lonlat=False)
 def test_pix2ang(nside_pow, frac, nest, lonlat):
     nside = 2 ** nside_pow
     ipix = int(frac * 12 * nside ** 2)


### PR DESCRIPTION
@lpsinger - https://github.com/astropy/astropy-healpix/issues/80 is not related to PPC, it is just a failure that happened to appear in that build. This PR adds that specific example to the hypothesis test and this fails for me locally on Mac. I don't have time to investigate why this is happening, so if anyone has any time please feel free to!