### PR TITLE
Fix docstrings for 32 bit architectures

### DIFF
--- a/docs/cone_search.rst
+++ b/docs/cone_search.rst
@@ -15,10 +15,10 @@ longitude/latitude::
     >>> from astropy import units as u
     >>> from astropy_healpix import HEALPix
     >>> hp = HEALPix(nside=16, order='nested')
-    >>> hp.cone_search_lonlat(10 * u.deg, 30 * u.deg, radius=10 * u.deg)
-    array([1269,  160,  162, 1271, 1270, 1268, 1246, 1247,  138,  139,  161,
-           1245,  136,  137,  140,  142,  130,  131, 1239, 1244, 1238, 1241,
-           1243, 1265, 1267, 1276, 1273, 1277,  168,  169,  163,  166,  164])
+    >>> print(hp.cone_search_lonlat(10 * u.deg, 30 * u.deg, radius=10 * u.deg))
+    [1269  160  162 1271 1270 1268 1246 1247  138  139  161 1245  136  137
+      140  142  130  131 1239 1244 1238 1241 1243 1265 1267 1276 1273 1277
+      168  169  163  166  164]
 
 Likewise, if a celestial frame was specified using the ``frame`` keyword arguent
 to :class:`~astropy_healpix.HEALPix`, you can use the
@@ -29,5 +29,5 @@ around specific celestial coordinates::
     >>> hp = HEALPix(nside=16, order='nested', frame=Galactic())
     >>> from astropy.coordinates import SkyCoord
     >>> coord = SkyCoord('00h42m44.3503s +41d16m08.634s')
-    >>> hp.cone_search_skycoord(coord, radius=5 * u.arcmin)
-    array([2537])
+    >>> print(hp.cone_search_skycoord(coord, radius=5 * u.arcmin))
+    [2537]

--- a/docs/coordinates.rst
+++ b/docs/coordinates.rst
@@ -35,8 +35,8 @@ Conversely, given longitudes and latitudes as :class:`~astropy.units.Quantity`
 objects, it is possible to recover HEALPix pixel indices::
 
     >>> from astropy import units as u
-    >>> hp.lonlat_to_healpix([1, 3, 4] * u.deg, [5, 6, 9] * u.deg)
-    array([1217, 1217, 1222])
+    >>> print(hp.lonlat_to_healpix([1, 3, 4] * u.deg, [5, 6, 9] * u.deg))
+    [1217 1217 1222]
 
 In these examples, what is being converted is the position of the center of each
 pixel. In fact, the  :meth:`~astropy_healpix.HEALPix.lonlat_to_healpix` method can also
@@ -44,8 +44,8 @@ take or give the fractional position inside each HEALPix pixel, e.g.::
 
     >>> index, dx, dy = hp.lonlat_to_healpix([1, 3, 4] * u.deg, [5, 6, 9] * u.deg,
     ...                                      return_offsets=True)
-    >>> index
-    array([1217, 1217, 1222])
+    >>> print(index)
+    [1217 1217 1222]
     >>> dx  # doctest: +FLOAT_CMP
     array([ 0.22364669,  0.78767489,  0.58832469])
     >>> dy  # doctest: +FLOAT_CMP
@@ -103,10 +103,10 @@ The :class:`~astropy_healpix.HEALPix` class has methods that can be used to
 convert HEALPix pixel indices between the ring and nested convention. These are
 :meth:`~astropy_healpix.HEALPix.nested_to_ring`::
 
-    >>> hp.nested_to_ring([30])
-    array([873])
+    >>> print(hp.nested_to_ring([30]))
+    [873]
 
 and :meth:`~astropy_healpix.HEALPix.ring_to_nested`::
 
-    >>> hp.ring_to_nested([1, 2, 3])
-    array([ 511,  767, 1023])
+    >>> print(hp.ring_to_nested([1, 2, 3]))
+    [ 511  767 1023]


### PR DESCRIPTION
We return HEALPix indices as `np.int64`, which is the Numpy index type on 64-bit but not 32-bit platforms. On 32-bit platforms, Numpy will add `dtype=int64` to string representations of these arrays, which causes some doctests to fail.

This workaround calls `print()`, which always prints just the members of the array.

Fixes #81.