### PR TITLE
Fix make in  cextern/astrometry.net/Makefile

### DIFF
--- a/cextern/.gitignore
+++ b/cextern/.gitignore
@@ -1,0 +1,2 @@
+astrometry.net/test_healpix
+astrometry.net/example

--- a/cextern/README.md
+++ b/cextern/README.md
@@ -1,0 +1,13 @@
+# astropy-healpix/cextern/
+
+The `astropy-healpix` Python package is a wrapper around a C library.
+See http://astropy-healpix.readthedocs.io/en/latest/about.html
+
+This README gives some technical details on the C code here.
+
+- The main file is `healpix.h` and `healpix.c`, start reading there first.
+- For the Python `astropy-healpix` packge, the C code is built via `setup.py`
+- However, to help work on the C code and test it directly, a `Makefile`
+  is included here.
+- For testing, a copy of `CuTest.h` and `CuTest.c` from here is bundled:
+  https://github.com/asimjalis/cutest

--- a/cextern/astrometry.net/CuTest.c
+++ b/cextern/astrometry.net/CuTest.c
@@ -1,0 +1,340 @@
+#include <assert.h>
+#include <setjmp.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <math.h>
+
+#include "CuTest.h"
+
+/*-------------------------------------------------------------------------*
+ * CuStr
+ *-------------------------------------------------------------------------*/
+
+char* CuStrAlloc(int size)
+{
+	char* newStr = (char*) malloc( sizeof(char) * (size) );
+	return newStr;
+}
+
+char* CuStrCopy(const char* old)
+{
+	int len = strlen(old);
+	char* newStr = CuStrAlloc(len + 1);
+	strcpy(newStr, old);
+	return newStr;
+}
+
+/*-------------------------------------------------------------------------*
+ * CuString
+ *-------------------------------------------------------------------------*/
+
+void CuStringInit(CuString* str)
+{
+	str->length = 0;
+	str->size = STRING_MAX;
+	str->buffer = (char*) malloc(sizeof(char) * str->size);
+	str->buffer[0] = '\0';
+}
+
+CuString* CuStringNew(void)
+{
+	CuString* str = (CuString*) malloc(sizeof(CuString));
+	str->length = 0;
+	str->size = STRING_MAX;
+	str->buffer = (char*) malloc(sizeof(char) * str->size);
+	str->buffer[0] = '\0';
+	return str;
+}
+
+void CuStringDelete(CuString *str)
+{
+        if (!str) return;
+        free(str->buffer);
+        free(str);
+}
+
+void CuStringResize(CuString* str, int newSize)
+{
+	str->buffer = (char*) realloc(str->buffer, sizeof(char) * newSize);
+	str->size = newSize;
+}
+
+void CuStringAppend(CuString* str, const char* text)
+{
+	int length;
+
+	if (text == NULL) {
+		text = "NULL";
+	}
+
+	length = strlen(text);
+	if (str->length + length + 1 >= str->size)
+		CuStringResize(str, str->length + length + 1 + STRING_INC);
+	str->length += length;
+	strcat(str->buffer, text);
+}
+
+void CuStringAppendChar(CuString* str, char ch)
+{
+	char text[2];
+	text[0] = ch;
+	text[1] = '\0';
+	CuStringAppend(str, text);
+}
+
+void CuStringAppendFormat(CuString* str, const char* format, ...)
+{
+	va_list argp;
+	char buf[HUGE_STRING_LEN];
+	va_start(argp, format);
+	vsprintf(buf, format, argp);
+	va_end(argp);
+	CuStringAppend(str, buf);
+}
+
+void CuStringInsert(CuString* str, const char* text, int pos)
+{
+	int length = strlen(text);
+	if (pos > str->length)
+		pos = str->length;
+	if (str->length + length + 1 >= str->size)
+		CuStringResize(str, str->length + length + 1 + STRING_INC);
+	memmove(str->buffer + pos + length, str->buffer + pos, (str->length - pos) + 1);
+	str->length += length;
+	memcpy(str->buffer + pos, text, length);
+}
+
+/*-------------------------------------------------------------------------*
+ * CuTest
+ *-------------------------------------------------------------------------*/
+
+void CuTestInit(CuTest* t, const char* name, TestFunction function)
+{
+	t->name = CuStrCopy(name);
+	t->failed = 0;
+	t->ran = 0;
+	t->message = NULL;
+	t->function = function;
+	t->jumpBuf = NULL;
+}
+
+CuTest* CuTestNew(const char* name, TestFunction function)
+{
+	CuTest* tc = CU_ALLOC(CuTest);
+	CuTestInit(tc, name, function);
+	return tc;
+}
+
+void CuTestDelete(CuTest *t)
+{
+        if (!t) return;
+        free(t->name);
+        free(t);
+}
+
+void CuTestRun(CuTest* tc)
+{
+	jmp_buf buf;
+	tc->jumpBuf = &buf;
+	if (setjmp(buf) == 0)
+	{
+		tc->ran = 1;
+		(tc->function)(tc);
+	}
+	tc->jumpBuf = 0;
+}
+
+static void CuFailInternal(CuTest* tc, const char* file, int line, CuString* string)
+{
+	char buf[HUGE_STRING_LEN];
+
+	sprintf(buf, "%s:%d: ", file, line);
+	CuStringInsert(string, buf, 0);
+
+	tc->failed = 1;
+	tc->message = string->buffer;
+	if (tc->jumpBuf != 0) longjmp(*(tc->jumpBuf), 0);
+}
+
+void CuFail_Line(CuTest* tc, const char* file, int line, const char* message2, const char* message)
+{
+	CuString string;
+
+	CuStringInit(&string);
+	if (message2 != NULL) 
+	{
+		CuStringAppend(&string, message2);
+		CuStringAppend(&string, ": ");
+	}
+	CuStringAppend(&string, message);
+	CuFailInternal(tc, file, line, &string);
+}
+
+void CuAssert_Line(CuTest* tc, const char* file, int line, const char* message, int condition)
+{
+	if (condition) return;
+	CuFail_Line(tc, file, line, NULL, message);
+}
+
+void CuAssertStrEquals_LineMsg(CuTest* tc, const char* file, int line, const char* message, 
+	const char* expected, const char* actual)
+{
+	CuString string;
+	if ((expected == NULL && actual == NULL) ||
+	    (expected != NULL && actual != NULL &&
+	     strcmp(expected, actual) == 0))
+	{
+		return;
+	}
+
+	CuStringInit(&string);
+	if (message != NULL) 
+	{
+		CuStringAppend(&string, message);
+		CuStringAppend(&string, ": ");
+	}
+	CuStringAppend(&string, "expected <");
+	CuStringAppend(&string, expected);
+	CuStringAppend(&string, "> but was <");
+	CuStringAppend(&string, actual);
+	CuStringAppend(&string, ">");
+	CuFailInternal(tc, file, line, &string);
+}
+
+void CuAssertIntEquals_LineMsg(CuTest* tc, const char* file, int line, const char* message, 
+	int expected, int actual)
+{
+	char buf[STRING_MAX];
+	if (expected == actual) return;
+	sprintf(buf, "expected <%d> but was <%d>", expected, actual);
+	CuFail_Line(tc, file, line, message, buf);
+}
+
+void CuAssertDblEquals_LineMsg(CuTest* tc, const char* file, int line, const char* message, 
+	double expected, double actual, double delta)
+{
+	char buf[STRING_MAX];
+	if (fabs(expected - actual) <= delta) return;
+/*	sprintf(buf, "expected <%lf> but was <%lf>", expected, actual); */
+	sprintf(buf, "expected <%f> but was <%f>", expected, actual); 
+
+	CuFail_Line(tc, file, line, message, buf);
+}
+
+void CuAssertPtrEquals_LineMsg(CuTest* tc, const char* file, int line, const char* message, 
+	void* expected, void* actual)
+{
+	char buf[STRING_MAX];
+	if (expected == actual) return;
+	sprintf(buf, "expected pointer <0x%p> but was <0x%p>", expected, actual);
+	CuFail_Line(tc, file, line, message, buf);
+}
+
+
+/*-------------------------------------------------------------------------*
+ * CuSuite
+ *-------------------------------------------------------------------------*/
+
+void CuSuiteInit(CuSuite* testSuite)
+{
+	testSuite->count = 0;
+	testSuite->failCount = 0;
+        memset(testSuite->list, 0, sizeof(testSuite->list));
+}
+
+CuSuite* CuSuiteNew(void)
+{
+	CuSuite* testSuite = CU_ALLOC(CuSuite);
+	CuSuiteInit(testSuite);
+	return testSuite;
+}
+
+void CuSuiteDelete(CuSuite *testSuite)
+{
+        unsigned int n;
+        for (n=0; n < MAX_TEST_CASES; n++)
+        {
+                if (testSuite->list[n])
+                {
+                        CuTestDelete(testSuite->list[n]);
+                }
+        }
+        free(testSuite);
+
+}
+
+void CuSuiteAdd(CuSuite* testSuite, CuTest *testCase)
+{
+	assert(testSuite->count < MAX_TEST_CASES);
+	testSuite->list[testSuite->count] = testCase;
+	testSuite->count++;
+}
+
+void CuSuiteAddSuite(CuSuite* testSuite, CuSuite* testSuite2)
+{
+	int i;
+	for (i = 0 ; i < testSuite2->count ; ++i)
+	{
+		CuTest* testCase = testSuite2->list[i];
+		CuSuiteAdd(testSuite, testCase);
+	}
+}
+
+void CuSuiteRun(CuSuite* testSuite)
+{
+	int i;
+	for (i = 0 ; i < testSuite->count ; ++i)
+	{
+		CuTest* testCase = testSuite->list[i];
+		CuTestRun(testCase);
+		if (testCase->failed) { testSuite->failCount += 1; }
+	}
+}
+
+void CuSuiteSummary(CuSuite* testSuite, CuString* summary)
+{
+	int i;
+	for (i = 0 ; i < testSuite->count ; ++i)
+	{
+		CuTest* testCase = testSuite->list[i];
+		CuStringAppend(summary, testCase->failed ? "F" : ".");
+	}
+	CuStringAppend(summary, "\n\n");
+}
+
+void CuSuiteDetails(CuSuite* testSuite, CuString* details)
+{
+	int i;
+	int failCount = 0;
+
+	if (testSuite->failCount == 0)
+	{
+		int passCount = testSuite->count - testSuite->failCount;
+		const char* testWord = passCount == 1 ? "test" : "tests";
+		CuStringAppendFormat(details, "OK (%d %s)\n", passCount, testWord);
+	}
+	else
+	{
+		if (testSuite->failCount == 1)
+			CuStringAppend(details, "There was 1 failure:\n");
+		else
+			CuStringAppendFormat(details, "There were %d failures:\n", testSuite->failCount);
+
+		for (i = 0 ; i < testSuite->count ; ++i)
+		{
+			CuTest* testCase = testSuite->list[i];
+			if (testCase->failed)
+			{
+				failCount++;
+				CuStringAppendFormat(details, "%d) %s: %s\n",
+					failCount, testCase->name, testCase->message);
+			}
+		}
+		CuStringAppend(details, "\n!!!FAILURES!!!\n");
+
+		CuStringAppendFormat(details, "Runs: %d ",   testSuite->count);
+		CuStringAppendFormat(details, "Passes: %d ", testSuite->count - testSuite->failCount);
+		CuStringAppendFormat(details, "Fails: %d\n",  testSuite->failCount);
+	}
+}

--- a/cextern/astrometry.net/CuTest.h
+++ b/cextern/astrometry.net/CuTest.h
@@ -1,0 +1,114 @@
+#ifndef CU_TEST_H
+#define CU_TEST_H
+
+#include <setjmp.h>
+#include <stdarg.h>
+
+/* CuString */
+
+char* CuStrAlloc(int size);
+char* CuStrCopy(const char* old);
+
+#define CU_ALLOC(TYPE)		((TYPE*) malloc(sizeof(TYPE)))
+
+#define HUGE_STRING_LEN	8192
+#define STRING_MAX		256
+#define STRING_INC		256
+
+typedef struct
+{
+	int length;
+	int size;
+	char* buffer;
+} CuString;
+
+void CuStringInit(CuString* str);
+CuString* CuStringNew(void);
+void CuStringRead(CuString* str, const char* path);
+void CuStringAppend(CuString* str, const char* text);
+void CuStringAppendChar(CuString* str, char ch);
+void CuStringAppendFormat(CuString* str, const char* format, ...);
+void CuStringInsert(CuString* str, const char* text, int pos);
+void CuStringResize(CuString* str, int newSize);
+void CuStringDelete(CuString* str);
+
+/* CuTest */
+
+typedef struct CuTest CuTest;
+
+typedef void (*TestFunction)(CuTest *);
+
+struct CuTest
+{
+	char* name;
+	TestFunction function;
+	int failed;
+	int ran;
+	const char* message;
+	jmp_buf *jumpBuf;
+};
+
+void CuTestInit(CuTest* t, const char* name, TestFunction function);
+CuTest* CuTestNew(const char* name, TestFunction function);
+void CuTestRun(CuTest* tc);
+void CuTestDelete(CuTest *t);
+
+/* Internal versions of assert functions -- use the public versions */
+void CuFail_Line(CuTest* tc, const char* file, int line, const char* message2, const char* message);
+void CuAssert_Line(CuTest* tc, const char* file, int line, const char* message, int condition);
+void CuAssertStrEquals_LineMsg(CuTest* tc, 
+	const char* file, int line, const char* message, 
+	const char* expected, const char* actual);
+void CuAssertIntEquals_LineMsg(CuTest* tc, 
+	const char* file, int line, const char* message, 
+	int expected, int actual);
+void CuAssertDblEquals_LineMsg(CuTest* tc, 
+	const char* file, int line, const char* message, 
+	double expected, double actual, double delta);
+void CuAssertPtrEquals_LineMsg(CuTest* tc, 
+	const char* file, int line, const char* message, 
+	void* expected, void* actual);
+
+/* public assert functions */
+
+#define CuFail(tc, ms)                        CuFail_Line(  (tc), __FILE__, __LINE__, NULL, (ms))
+#define CuAssert(tc, ms, cond)                CuAssert_Line((tc), __FILE__, __LINE__, (ms), (cond))
+#define CuAssertTrue(tc, cond)                CuAssert_Line((tc), __FILE__, __LINE__, "assert failed", (cond))
+
+#define CuAssertStrEquals(tc,ex,ac)           CuAssertStrEquals_LineMsg((tc),__FILE__,__LINE__,NULL,(ex),(ac))
+#define CuAssertStrEquals_Msg(tc,ms,ex,ac)    CuAssertStrEquals_LineMsg((tc),__FILE__,__LINE__,(ms),(ex),(ac))
+#define CuAssertIntEquals(tc,ex,ac)           CuAssertIntEquals_LineMsg((tc),__FILE__,__LINE__,NULL,(ex),(ac))
+#define CuAssertIntEquals_Msg(tc,ms,ex,ac)    CuAssertIntEquals_LineMsg((tc),__FILE__,__LINE__,(ms),(ex),(ac))
+#define CuAssertDblEquals(tc,ex,ac,dl)        CuAssertDblEquals_LineMsg((tc),__FILE__,__LINE__,NULL,(ex),(ac),(dl))
+#define CuAssertDblEquals_Msg(tc,ms,ex,ac,dl) CuAssertDblEquals_LineMsg((tc),__FILE__,__LINE__,(ms),(ex),(ac),(dl))
+#define CuAssertPtrEquals(tc,ex,ac)           CuAssertPtrEquals_LineMsg((tc),__FILE__,__LINE__,NULL,(ex),(ac))
+#define CuAssertPtrEquals_Msg(tc,ms,ex,ac)    CuAssertPtrEquals_LineMsg((tc),__FILE__,__LINE__,(ms),(ex),(ac))
+
+#define CuAssertPtrNotNull(tc,p)        CuAssert_Line((tc),__FILE__,__LINE__,"null pointer unexpected",(p != NULL))
+#define CuAssertPtrNotNullMsg(tc,msg,p) CuAssert_Line((tc),__FILE__,__LINE__,(msg),(p != NULL))
+
+/* CuSuite */
+
+#define MAX_TEST_CASES	1024
+
+#define SUITE_ADD_TEST(SUITE,TEST)	CuSuiteAdd(SUITE, CuTestNew(#TEST, TEST))
+
+typedef struct
+{
+	int count;
+	CuTest* list[MAX_TEST_CASES];
+	int failCount;
+
+} CuSuite;
+
+
+void CuSuiteInit(CuSuite* testSuite);
+CuSuite* CuSuiteNew(void);
+void CuSuiteDelete(CuSuite *testSuite);
+void CuSuiteAdd(CuSuite* testSuite, CuTest *testCase);
+void CuSuiteAddSuite(CuSuite* testSuite, CuSuite* testSuite2);
+void CuSuiteRun(CuSuite* testSuite);
+void CuSuiteSummary(CuSuite* testSuite, CuString* summary);
+void CuSuiteDetails(CuSuite* testSuite, CuString* details);
+
+#endif /* CU_TEST_H */

--- a/cextern/astrometry.net/Makefile
+++ b/cextern/astrometry.net/Makefile
@@ -11,4 +11,4 @@ $(OBJS): %.o: %.c $(HEADERS)
 %.o: %.c
 	$(CC) -o $@ -c $<
 
-test_healpix: test_healpix-main.c test_healpix.c $(OBJS) cutest.o
+test_healpix: test_healpix-main.c test_healpix.c $(OBJS) CuTest.o

--- a/cextern/astrometry.net/Makefile
+++ b/cextern/astrometry.net/Makefile
@@ -12,3 +12,5 @@ $(OBJS): %.o: %.c $(HEADERS)
 	$(CC) -o $@ -c $<
 
 test_healpix: test_healpix-main.c test_healpix.c $(OBJS) CuTest.o
+
+example: example.c $(OBJS)

--- a/cextern/astrometry.net/Makefile
+++ b/cextern/astrometry.net/Makefile
@@ -1,7 +1,7 @@
 
 all: test_healpix
 
-OBJS = healpix-utils.o healpix.o starutil.o permutedsort.o mathutil.o bl.o ioutils.o tic.o errors.o log.o qsort_reentrant.o
+OBJS = healpix-utils.o healpix.o starutil.o permutedsort.o mathutil.o bl.o qsort_reentrant.o
 
 HEADERS = healpix-utils.h healpix.h
 

--- a/cextern/astrometry.net/example.c
+++ b/cextern/astrometry.net/example.c
@@ -1,0 +1,10 @@
+// Simple hello world example
+#include <stdio.h>
+#include "healpix.h"
+
+int main(int argc, char const *argv[])
+{
+    double side_length = healpix_side_length_arcmin(4);
+    printf("side_length: %f\n", side_length);
+    return 0;
+}

--- a/cextern/astrometry.net/healpix.h
+++ b/cextern/astrometry.net/healpix.h
@@ -243,12 +243,7 @@ int64_t radecdegtohealpixlf(double ra, double dec, int Nside, double* dx, double
 /**
    Converts (x,y,z) coordinates on the unit sphere into a healpix index.
  */
-Const int xyztohealpix(double x, double y, double z, int Nside);
-
 Const int64_t xyztohealpixl(double x, double y, double z, int Nside);
-
-int xyztohealpixf(double x, double y, double z, int Nside,
-                  double* p_dx, double* p_dy);
 
 int64_t xyztohealpixlf(double x, double y, double z, int Nside,
 					   double* p_dx, double* p_dy);
@@ -270,7 +265,7 @@ int xyzarrtohealpixf(const double* xyz,int Nside, double* p_dx, double* p_dy);
    the northernmost corner, (1,0) is the easternmost, and (0,1) the
    westernmost.
 */
-void healpix_to_xyz(int64_t hp, int Nside, double dx, double dy,
+void healpixl_to_xyz(int64_t hp, int Nside, double dx, double dy,
                     double* p_x, double *p_y, double *p_z);
 
 /**

--- a/cextern/astrometry.net/test_healpix-main.c
+++ b/cextern/astrometry.net/test_healpix-main.c
@@ -6,7 +6,7 @@
 #include <string.h>
 #include <stdlib.h>
 
-#include "cutest.h"
+#include "CuTest.h"
 
 
 extern void test_side_length(CuTest*);

--- a/cextern/astrometry.net/test_healpix-main.c
+++ b/cextern/astrometry.net/test_healpix-main.c
@@ -22,7 +22,6 @@ void RunAllTests(void)
     CuString *output = CuStringNew();
     CuSuite* suite = CuSuiteNew();
 
-
     SUITE_ADD_TEST(suite, test_side_length);
     SUITE_ADD_TEST(suite, test_make_map);
     SUITE_ADD_TEST(suite, test_healpix_distance_to_radec);
@@ -36,16 +35,9 @@ void RunAllTests(void)
 
     printf("%s\n", output->buffer);
 
-    CuSuiteFree(suite);
-    CuStringFree(output);
 }
 
 int main(int argc, char** args)
 {
-    if (argc > 1 && !strcmp(args[1], "-d")) {
-        printf("Setting die on fail.\n");
-        CuDieOnFail();
-    }
     RunAllTests();
-    return 0;
 }

--- a/cextern/astrometry.net/test_healpix.c
+++ b/cextern/astrometry.net/test_healpix.c
@@ -8,7 +8,7 @@
 #include <assert.h>
 
 #include "os-features.h"
-#include "cutest.h"
+#include "CuTest.h"
 #include "starutil.h"
 #include "healpix.h"
 #include "bl.h"

--- a/cextern/astrometry.net/test_healpix.c
+++ b/cextern/astrometry.net/test_healpix.c
@@ -84,9 +84,9 @@ static void hpmap(int nside, const char* fn) {
 #endif
   double xyz[3];
   double range;
-  int hps[9];
+  int64_t hps[9];
   int i;
-  int hp;
+  int64_t hp;
   double dx, dy;
 
   // pick a point on the edge.
@@ -172,19 +172,19 @@ int tst_xyztohpf(CuTest* ct,
   int outhp;
   double outx,outy,outz;
   double dist;
-  healpix_to_xyz(hp, nside, dx, dy, &x, &y, &z);
-  outhp = xyztohealpixf(x, y, z, nside, &outdx, &outdy);
-  healpix_to_xyz(outhp, nside, outdx, outdy, &outx, &outy, &outz);
+  healpixl_to_xyz(hp, nside, dx, dy, &x, &y, &z);
+  outhp = xyztohealpixlf(x, y, z, nside, &outdx, &outdy);
+  healpixl_to_xyz(outhp, nside, outdx, outdy, &outx, &outy, &outz);
   dist = sqrt(MAX(0, square(x-outx) + square(y-outy) + square(z-outz)));
   printf("true/computed:\n"
-	 "hp: %i / %i\n"
+	 "hp: %d / %d\n"
 	 "dx: %.20g / %.20g\n"
 	 "dy: %.20g / %.20g\n"
 	 "x:  %g / %g\n"
 	 "y:  %g / %g\n"
 	 "z:  %g / %g\n"
 	 "dist: %g\n\n",
-	 hp, outhp, dx, outdx, dy, outdy,
+	 (int)hp, (int)outhp, dx, outdx, dy, outdy,
 	 x, outx, y, outy, z, outz, dist);
 
   if (dist > 1e-6) {
@@ -227,7 +227,7 @@ void tEst_xyztohpf(CuTest* ct) {
       fprintf(stderr, "xp=[]\n");
       fprintf(stderr, "yp=[]\n");
       for (dy=0.0; dy<=1.05; dy+=step) {
-	healpix_to_xyz(hp, nside, dx, dy, &x, &y, &z);
+	healpixl_to_xyz(hp, nside, dx, dy, &x, &y, &z);
 	a = xy2ra(x,y) / (2.0 * M_PI);
 	b = z2dec(z) / (M_PI);
 	fprintf(stderr, "xp.append(%g)\n", a);
@@ -239,7 +239,7 @@ void tEst_xyztohpf(CuTest* ct) {
       fprintf(stderr, "xp=[]\n");
       fprintf(stderr, "yp=[]\n");
       for (dx=0.0; dx<=1.0; dx+=step) {
-	healpix_to_xyz(hp, nside, dx, dy, &x, &y, &z);
+	healpixl_to_xyz(hp, nside, dx, dy, &x, &y, &z);
 	a = xy2ra(x,y) / (2.0 * M_PI);
 	b = z2dec(z) / (M_PI);
 	fprintf(stderr, "xp.append(%g)\n", a);
@@ -271,7 +271,7 @@ static void tst_neighbours(CuTest* ct, int pix, int* true_neigh, int true_nn,
   int i;
   for (i=0; i<8; i++)
     neigh[i] = -1;
-  nn = healpix_get_neighbours(pix, neigh, Nside);
+  healpixl_get_neighbours(pix, neigh, Nside);
   /*
     printf("true(%i) : [ ", pix);
     for (i=0; i<true_nn; i++)
@@ -282,7 +282,6 @@ static void tst_neighbours(CuTest* ct, int pix, int* true_neigh, int true_nn,
     printf("%u, ", neigh[i]);
     printf("]\n");
   */
-  CuAssertIntEquals(ct, nn, true_nn);
 
   for (i=0; i<true_nn; i++)
     CuAssertIntEquals(ct, true_neigh[i], neigh[i]);
@@ -303,11 +302,11 @@ static void tst_nested(CuTest* ct, int pix, int* true_neigh, int true_nn,
 
   CuAssert(ct, "true_nn <= 8", true_nn <= 8);
   for (i=0; i<true_nn; i++) {
-    truexy[i] = healpix_nested_to_xy(true_neigh[i], Nside);
-    CuAssertIntEquals(ct, true_neigh[i], healpix_xy_to_nested(truexy[i], Nside));
+    truexy[i] = healpixl_nested_to_xy(true_neigh[i], Nside);
+    CuAssertIntEquals(ct, true_neigh[i], healpixl_xy_to_nested(truexy[i], Nside));
   }
-  xypix = healpix_nested_to_xy(pix, Nside);
-  CuAssertIntEquals(ct, pix, healpix_xy_to_nested(xypix, Nside));
+  xypix = healpixl_nested_to_xy(pix, Nside);
+  CuAssertIntEquals(ct, pix, healpixl_xy_to_nested(xypix, Nside));
 
   tst_neighbours(ct, xypix, truexy, true_nn, Nside);
 }
@@ -315,7 +314,6 @@ static void tst_nested(CuTest* ct, int pix, int* true_neigh, int true_nn,
 void print_node(double z, double phi, int Nside) {
   double ra, dec;
   int hp;
-  int nn;
   int neigh[8];
   int k;
 
@@ -329,12 +327,12 @@ void print_node(double z, double phi, int Nside) {
     ra -= 2.0 * M_PI;
 
   // find its healpix.
-  hp = radec_to_healpix(ra, dec, Nside);
+  hp = radec_to_healpixl(ra, dec, Nside);
   // find its neighbourhood.
-  nn = healpix_get_neighbours(hp, neigh, Nside);
+  healpixl_get_neighbours(hp, neigh, Nside);
   fprintf(stderr, "  N%i [ label=\"%i\", pos=\"%g,%g!\" ];\n", hp, hp,
 	  scale * ra/M_PI, scale * z);
-  for (k=0; k<nn; k++) {
+  for (k=0; k<8; k++) {
     fprintf(stderr, "  N%i -- N%i\n", hp, neigh[k]);
   }
 }
@@ -575,7 +573,7 @@ void print_healpix_grid(int Nside) {
   fprintf(stderr, "x%i=[", Nside);
   for (i=0; i<N; i++) {
     for (j=0; j<N; j++) {
-      fprintf(stderr, "%i ", radec_to_healpix(i*2*M_PI/N, M_PI*(j-N/2)/N, Nside));
+      fprintf(stderr, "%i ", radec_to_healpixl(i*2*M_PI/N, M_PI*(j-N/2)/N, Nside));
     }
     fprintf(stderr, ";");
   }
@@ -591,7 +589,7 @@ void print_healpix_borders(int Nside) {
   fprintf(stderr, "x%i=[", Nside);
   for (i=0; i<N; i++) {
     for (j=0; j<N; j++) {
-      fprintf(stderr, "%i ", radec_to_healpix(i*2*M_PI/N, M_PI*(j-N/2)/N, Nside));
+      fprintf(stderr, "%i ", radec_to_healpixl(i*2*M_PI/N, M_PI*(j-N/2)/N, Nside));
     }
     fprintf(stderr, ";");
   }
@@ -657,16 +655,18 @@ void test_distortion_at_pole(CuTest* ct) {
     healpixl_to_radecdeg(hp, Nside, 1, 1, &ra3, &dec3);
     healpixl_to_radecdeg(hp, Nside, 1, 0, &ra4, &dec4);
 
-    // sides
-    d1 = arcsec_between_radecdeg(ra1, dec1, ra2, dec2);
-    d2 = arcsec_between_radecdeg(ra2, dec2, ra3, dec3);
-    d3 = arcsec_between_radecdeg(ra3, dec3, ra4, dec4);
-    d4 = arcsec_between_radecdeg(ra4, dec4, ra1, dec1);
-    // diagonals
-    d5 = arcsec_between_radecdeg(ra1, dec1, ra3, dec3);
-    d6 = arcsec_between_radecdeg(ra2, dec2, ra4, dec4);
+    // FIXME: implement or remove
+    // At the moment `arcsec_between_radecdeg` is not included here.
+    // // sides
+    // d1 = arcsec_between_radecdeg(ra1, dec1, ra2, dec2);
+    // d2 = arcsec_between_radecdeg(ra2, dec2, ra3, dec3);
+    // d3 = arcsec_between_radecdeg(ra3, dec3, ra4, dec4);
+    // d4 = arcsec_between_radecdeg(ra4, dec4, ra1, dec1);
+    // // diagonals
+    // d5 = arcsec_between_radecdeg(ra1, dec1, ra3, dec3);
+    // d6 = arcsec_between_radecdeg(ra2, dec2, ra4, dec4);
 
-    printf("%-15s (%4.1f, %4.1f): %-5.3f, %-5.3f, %-5.3f, %-5.3f / %-5.3f, %-5.3f\n", testnames[i], ra, dec, d1, d2, d3, d4, d5, d6);
+    // printf("%-15s (%4.1f, %4.1f): %-5.3f, %-5.3f, %-5.3f, %-5.3f / %-5.3f, %-5.3f\n", testnames[i], ra, dec, d1, d2, d3, d4, d5, d6);
   }
 }
 
@@ -680,8 +680,6 @@ int main(int argc, char** args) {
 
   /* Add new tests here */
   SUITE_ADD_TEST(suite, test_healpix_neighbours);
-  SUITE_ADD_TEST(suite, test_healpix_pnprime_to_xy);
-  SUITE_ADD_TEST(suite, test_healpix_xy_to_pnprime);
   SUITE_ADD_TEST(suite, test_healpix_distance_to_radec);
 
   /* Run the suite, collect results and display */
@@ -711,7 +709,7 @@ int main(int argc, char** args) {
     ra = ((double)rastep / (double)(Nra-1)) * 2.0 * M_PI;
     for (decstep=0; decstep<Ndec; decstep++) {
     dec = (((double)decstep / (double)(Ndec-1)) * M_PI) - M_PI/2.0;
-    healpix = radec_to_healpix(ra, dec);
+    healpix = radec_to_healpixl(ra, dec);
     printf("radechealpix(%i,:)=[%g,%g,%i];\n",
     (rastep*Ndec) + decstep + 1, ra, dec, healpix);
     }


### PR DESCRIPTION
It would be nice to polish `cextern/astrometry.net` a bit as a C library (remove things that aren't needed, add a README, maybe move the `interpolate.c` here as well?

The first thing I wanted to do was build it and run the tests:
```
$ cd cextern/astrometry.net
$ make
cc -o qsort_reentrant.o -c qsort_reentrant.c
make: *** No rule to make target `cutest.o', needed by `test_healpix'.  Stop.
```
@dstndstn @astrofrog - Is that https://github.com/asimjalis/cutest ?
Should we use it here or is there something better to test a C lib?
If we use cutest: how? Should we bundle a copy of the files?https://github.com/asimjalis/cutest#getting-started