### PR TITLE
Fix docs intersphinx links to healpy

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -53,6 +53,11 @@ setup_cfg = dict(conf.items('metadata'))
 
 # -- General configuration ----------------------------------------------------
 
+intersphinx_mapping.pop('scipy', None)
+intersphinx_mapping.pop('h5py', None)
+intersphinx_mapping['healpy'] = ('https://healpy.readthedocs.io/en/latest/', None)
+
+
 # By default, highlight as Python 3.
 highlight_language = 'python3'
 


### PR DESCRIPTION
So far in the docs all intersphinx links to healpy were not working:
http://astropy-healpix.readthedocs.io/en/latest/api.html#module-astropy_healpix.healpy

This PR make it work.