### PR TITLE
Fix get_interp_weights for phi=None case

### DIFF
--- a/astropy_healpix/healpy.py
+++ b/astropy_healpix/healpy.py
@@ -178,8 +178,9 @@ def get_interp_weights(nside, theta, phi=None, nest=False, lonlat=False):
     Drop-in replacement for healpy `~healpy.get_interp_weights`, although
     note that the order of the weights and pixels may differ.
     """
+    # if phi is not given, theta is interpreted as pixel number
     if phi is None:
-        theta, phi = pix2ang(theta, nest=nest)
+        theta, phi = pix2ang(nside, ipix=theta, nest=nest)
     lon, lat = _healpy_to_lonlat(theta, phi, lonlat=lonlat)
     return bilinear_interpolation_weights(lon, lat, nside, order='nested' if nest else 'ring')
 


### PR DESCRIPTION
In `get_interp_weights` for the `phi=None` case we forgot to pass `nside` along to the `pix2ang` call.

This PR fixes that issue; (still no test coverage of that line, I'd prefer to move on and improve test coverage later)

http://healpy.readthedocs.io/en/latest/generated/healpy.pixelfunc.get_interp_weights.html