### PR TITLE
Uniq to levelipix methods

### DIFF
--- a/astropy_healpix/core.py
+++ b/astropy_healpix/core.py
@@ -115,7 +115,7 @@ def nside_to_level(nside):
     nside = np.asarray(nside, dtype=np.int64)
 
     _validate_nside(nside)
-    return np.log2(nside)
+    return np.log2(nside).astype(np.int64)
 
 
 def uniq_to_levelipix(uniq):

--- a/astropy_healpix/core.py
+++ b/astropy_healpix/core.py
@@ -138,7 +138,7 @@ def uniq_to_levelipix(uniq):
     """
     uniq = np.asarray(uniq, dtype=np.int64)
 
-    level = ((np.log2(uniq//4)) // 2)
+    level = (np.log2(uniq//4)) // 2
     level = level.astype(np.int64)
     _validate_level(level)
 

--- a/astropy_healpix/core.py
+++ b/astropy_healpix/core.py
@@ -18,6 +18,8 @@ __all__ = [
     'pixel_resolution_to_nside',
     'nside_to_npix',
     'npix_to_nside',
+    'level_to_nside',
+    'nside_to_level',
     'lonlat_to_healpix',
     'healpix_to_lonlat',
     'bilinear_interpolation_weights',
@@ -77,8 +79,33 @@ def level_to_nside(level):
     nside : int
         The number of pixels on the side of one of the 12 'top-level' HEALPix tiles.
     """
+    level = np.asarray(level, dtype=np.int64)
+
     _validate_level(level)
     return 2 ** level
+
+
+def nside_to_level(nside):
+    """
+    Find the HEALPix level for a given nside. (this is given by log2(nside))
+
+    This function is the inverse of `level_to_nside`.
+
+    Parameters
+    ----------
+    nside : int
+        The number of pixels on the side of one of the 12 'top-level' HEALPix tiles.
+        Must be a power of two.
+
+    Returns
+    -------
+    level : int
+        The level of the HEALPix cells
+    """
+    nside = np.asarray(nside, dtype=np.int64)
+
+    _validate_nside(nside)
+    return np.log2(nside)
 
 
 def nside_to_pixel_area(nside):

--- a/astropy_healpix/core.py
+++ b/astropy_healpix/core.py
@@ -20,8 +20,8 @@ __all__ = [
     'npix_to_nside',
     'level_to_nside',
     'nside_to_level',
-    'levelipix_to_uniq',
-    'uniq_to_levelipix',
+    'level_ipix_to_uniq',
+    'uniq_to_level_ipix',
     'lonlat_to_healpix',
     'healpix_to_lonlat',
     'bilinear_interpolation_weights',
@@ -118,11 +118,11 @@ def nside_to_level(nside):
     return np.log2(nside).astype(np.int64)
 
 
-def uniq_to_levelipix(uniq):
+def uniq_to_level_ipix(uniq):
     """
-	Convert a HEALPix cell uniq number to its (level, ipix) equivalent
+    Convert a HEALPix cell uniq number to its (level, ipix) equivalent.
 
-    A uniq number is a 64 bit integer equals to : ipix + 4*(4**level). Please read
+    A uniq number is a 64 bits integer equaling to : ipix + 4*(4**level). Please read
     this `paper <http://ivoa.net/documents/MOC/20140602/REC-MOC-1.0-20140602.pdf>`_
     for more details about uniq numbers.
 
@@ -148,11 +148,11 @@ def uniq_to_levelipix(uniq):
     return level, ipix
 
 
-def levelipix_to_uniq(level, ipix):
+def level_ipix_to_uniq(level, ipix):
     """
-    Convert a level and HEALPix index into a uniq number representing the cell
+    Convert a level and HEALPix index into a uniq number representing the cell.
 
-    This function is the inverse of `uniq_to_levelipix`.
+    This function is the inverse of `uniq_to_level_ipix`.
 
     Parameters
     ----------

--- a/astropy_healpix/core.py
+++ b/astropy_healpix/core.py
@@ -20,6 +20,8 @@ __all__ = [
     'npix_to_nside',
     'level_to_nside',
     'nside_to_level',
+    'levelipix_to_uniq',
+    'uniq_to_levelipix',
     'lonlat_to_healpix',
     'healpix_to_lonlat',
     'bilinear_interpolation_weights',
@@ -63,6 +65,9 @@ def _validate_nside(nside):
     if not np.all(2 ** log_2_nside == nside):
         raise ValueError('nside must be a power of two')
 
+def _validate_npix(level, ipix):
+    if not np.all(ipix < (3 << 2*(level + 1))):
+        raise ValueError('ipix for a specific level must be inferior to npix')
 
 def level_to_nside(level):
     """
@@ -106,6 +111,63 @@ def nside_to_level(nside):
 
     _validate_nside(nside)
     return np.log2(nside)
+
+
+def uniq_to_levelipix(uniq):
+    """
+	Convert a HEALPix cell uniq number to its (level, ipix) equivalent
+
+    A uniq number is a 64 bit integer equals to : ipix + 4*(4**level). Please read
+    this `paper <http://ivoa.net/documents/MOC/20140602/REC-MOC-1.0-20140602.pdf>`_
+    for more details about uniq numbers.
+
+    Parameters
+    ----------
+    uniq : int
+        The uniq number of a HEALPix cell.
+
+    Returns
+    -------
+    level, ipix: int, int
+        The level and index of the HEALPix cell computed from ``uniq``.
+    """
+    uniq = np.asarray(uniq, dtype=np.int64)
+
+    level = ((np.log2(uniq//4)) // 2)
+    level = level.astype(np.int64)
+    _validate_level(level)
+
+    ipix = uniq - (1 << 2*(level + 1))
+    _validate_npix(level, ipix)
+
+    return level, ipix
+
+
+def levelipix_to_uniq(level, ipix):
+    """
+    Convert a level and HEALPix index into a uniq number representing the cell
+
+    This function is the inverse of `uniq_to_levelipix`.
+
+    Parameters
+    ----------
+    level : int
+        The level of the HEALPix cell
+    ipix : int
+        The index of the HEALPix cell
+
+    Returns
+    -------
+    uniq : int
+        The uniq number representing the HEALPix cell.
+    """
+    level = np.asarray(level, dtype=np.int64)
+    ipix = np.asarray(ipix, dtype=np.int64)
+
+    _validate_level(level)
+    _validate_npix(level, ipix)
+
+    return ipix + (1 << 2*(level + 1))
 
 
 def nside_to_pixel_area(nside):

--- a/astropy_healpix/core.py
+++ b/astropy_healpix/core.py
@@ -65,14 +65,17 @@ def _validate_nside(nside):
     if not np.all(2 ** log_2_nside == nside):
         raise ValueError('nside must be a power of two')
 
+
 def _validate_npix(level, ipix):
     if not np.all(ipix < (3 << 2*(level + 1))):
         raise ValueError('ipix for a specific level must be inferior to npix')
 
+
 def level_to_nside(level):
     """
-    Find the pixel dimensions of the top-level HEALPix tiles given the
-    resolution level (this is given by 2**level).
+    Find the pixel dimensions of the top-level HEALPix tiles.
+
+    This is given by ``nside = 2**level``.
 
     Parameters
     ----------
@@ -92,7 +95,9 @@ def level_to_nside(level):
 
 def nside_to_level(nside):
     """
-    Find the HEALPix level for a given nside. (this is given by log2(nside))
+    Find the HEALPix level for a given nside.
+
+    This is given by ``level = log2(nside)``.
 
     This function is the inverse of `level_to_nside`.
 

--- a/astropy_healpix/tests/test_core.py
+++ b/astropy_healpix/tests/test_core.py
@@ -37,12 +37,12 @@ def test_nside_to_level():
     assert exc.value.args[0] == 'nside must be a power of two'
 
 
-@pytest.mark.parametrize("level, ipix, expected_nuniq", [
-    (0, 11, 11+4),
-    (15, 62540, 62540 + 4*4**15),
-])
-def test_levelipix_to_uniq(level, ipix, expected_nuniq):
-    assert ipix + 4*4**level == levelipix_to_uniq(level, ipix)
+def test_levelipix_to_uniq():
+    assert 11 + 4*4**0 == levelipix_to_uniq(0, 11)
+    assert 62540 + 4*4**15 == levelipix_to_uniq(15, 62540)
+    with pytest.raises(ValueError) as exc:
+        levelipix_to_uniq(1, 49)
+    assert exc.value.args[0] == 'ipix for a specific level must be inferior to npix'
 
 
 @pytest.mark.parametrize("level", [

--- a/astropy_healpix/tests/test_core.py
+++ b/astropy_healpix/tests/test_core.py
@@ -49,10 +49,12 @@ def test_level_ipix_to_uniq():
     0, 5, 10, 15, 20, 22, 25, 26, 27, 28, 29
 ])
 def test_uniq_to_level_ipix(level):
-    # Generate 10 HEALPix indexes for each level
     npix = 3 << 2*(level + 1)
-    # Take an ipix smaller than the maximum number of pixels for its level
-    ipix = npix >> 1
+    # Take 10 pixel indices between 0 and npix - 1
+    size = 10
+
+    ipix = np.arange(size, dtype=np.int64) * (npix // size)
+    level = np.ones(size) * level
 
     level_res, ipix_res = uniq_to_level_ipix(level_ipix_to_uniq(level, ipix))
     assert np.all(level_res == level) & np.all(ipix_res == ipix)

--- a/astropy_healpix/tests/test_core.py
+++ b/astropy_healpix/tests/test_core.py
@@ -52,7 +52,7 @@ def test_uniq_to_levelipix(level):
     # Generate 10 HEALPix indexes for each level
     size = 10
     npix = 3 << 2*(level + 1)
-    ipix_arr = np.random.randint(npix, size=size)
+    ipix_arr = np.random.randint(npix, size=size, dtype=np.int64)
     level_arr = np.ones(size) * level
 
     level_res_arr, ipix_res_arr = uniq_to_levelipix(levelipix_to_uniq(level_arr, ipix_arr))

--- a/astropy_healpix/tests/test_core.py
+++ b/astropy_healpix/tests/test_core.py
@@ -19,7 +19,7 @@ from ..core import (nside_to_pixel_area, nside_to_pixel_resolution, pixel_resolu
                     neighbours, healpix_cone_search, boundaries_lonlat,
                     level_to_nside, nside_to_level,
                     nested_to_ring, ring_to_nested,
-                    levelipix_to_uniq, uniq_to_levelipix,
+                    level_ipix_to_uniq, uniq_to_level_ipix,
                     bilinear_interpolation_weights)
 
 
@@ -37,18 +37,18 @@ def test_nside_to_level():
     assert exc.value.args[0] == 'nside must be a power of two'
 
 
-def test_levelipix_to_uniq():
-    assert 11 + 4*4**0 == levelipix_to_uniq(0, 11)
-    assert 62540 + 4*4**15 == levelipix_to_uniq(15, 62540)
+def test_level_ipix_to_uniq():
+    assert 11 + 4*4**0 == level_ipix_to_uniq(0, 11)
+    assert 62540 + 4*4**15 == level_ipix_to_uniq(15, 62540)
     with pytest.raises(ValueError) as exc:
-        levelipix_to_uniq(1, 49)
+        level_ipix_to_uniq(1, 49)
     assert exc.value.args[0] == 'ipix for a specific level must be inferior to npix'
 
 
 @pytest.mark.parametrize("level", [
     0, 5, 10, 15, 20, 22, 25, 26, 27, 28, 29
 ])
-def test_uniq_to_levelipix(level):
+def test_uniq_to_level_ipix(level):
     # Generate 10 HEALPix indexes for each level
     npix = 3 << 2*(level + 1)
     # Take an ipix smaller than the maximum number of pixels for its level

--- a/astropy_healpix/tests/test_core.py
+++ b/astropy_healpix/tests/test_core.py
@@ -19,6 +19,7 @@ from ..core import (nside_to_pixel_area, nside_to_pixel_resolution, pixel_resolu
                     neighbours, healpix_cone_search, boundaries_lonlat,
                     level_to_nside, nside_to_level,
                     nested_to_ring, ring_to_nested,
+                    levelipix_to_uniq, uniq_to_levelipix,
                     bilinear_interpolation_weights)
 
 
@@ -34,6 +35,28 @@ def test_nside_to_level():
     with pytest.raises(ValueError) as exc:
         nside_to_level(511)
     assert exc.value.args[0] == 'nside must be a power of two'
+
+
+@pytest.mark.parametrize("level, ipix, expected_nuniq", [
+    (0, 11, 11+4),
+    (15, 62540, 62540 + 4*4**15),
+])
+def test_levelipix_to_uniq(level, ipix, expected_nuniq):
+    assert ipix + 4*4**level == levelipix_to_uniq(level, ipix)
+
+
+@pytest.mark.parametrize("level", [
+    0, 5, 10, 15, 20, 22, 25, 26, 27, 28, 29
+])
+def test_uniq_to_levelipix(level):
+    # Generate 10 HEALPix indexes for each level
+    size = 10
+    npix = 3 << 2*(level + 1)
+    ipix_arr = np.random.randint(npix, size=size)
+    level_arr = np.ones(size) * level
+
+    level_res_arr, ipix_res_arr = uniq_to_levelipix(levelipix_to_uniq(level_arr, ipix_arr))
+    assert np.all(level_res_arr == level_arr) & np.all(ipix_res_arr == ipix_arr)
 
 
 def test_nside_to_pixel_area():

--- a/astropy_healpix/tests/test_core.py
+++ b/astropy_healpix/tests/test_core.py
@@ -17,7 +17,8 @@ from ..core import (nside_to_pixel_area, nside_to_pixel_resolution, pixel_resolu
                     nside_to_npix, npix_to_nside, healpix_to_lonlat,
                     lonlat_to_healpix, interpolate_bilinear_lonlat,
                     neighbours, healpix_cone_search, boundaries_lonlat,
-                    level_to_nside, nested_to_ring, ring_to_nested,
+                    level_to_nside, nside_to_level,
+                    nested_to_ring, ring_to_nested,
                     bilinear_interpolation_weights)
 
 
@@ -26,6 +27,13 @@ def test_level_to_nside():
     with pytest.raises(ValueError) as exc:
         level_to_nside(-1)
     assert exc.value.args[0] == 'level must be positive'
+
+
+def test_nside_to_level():
+    assert nside_to_level(1024) == 10
+    with pytest.raises(ValueError) as exc:
+        nside_to_level(511)
+    assert exc.value.args[0] == 'nside must be a power of two'
 
 
 def test_nside_to_pixel_area():

--- a/astropy_healpix/tests/test_core.py
+++ b/astropy_healpix/tests/test_core.py
@@ -50,13 +50,12 @@ def test_levelipix_to_uniq():
 ])
 def test_uniq_to_levelipix(level):
     # Generate 10 HEALPix indexes for each level
-    size = 10
     npix = 3 << 2*(level + 1)
-    ipix_arr = np.random.randint(npix, size=size, dtype=np.int64)
-    level_arr = np.ones(size) * level
+    # Take an ipix smaller than the maximum number of pixels for its level
+    ipix = npix >> 1
 
-    level_res_arr, ipix_res_arr = uniq_to_levelipix(levelipix_to_uniq(level_arr, ipix_arr))
-    assert np.all(level_res_arr == level_arr) & np.all(ipix_res_arr == ipix_arr)
+    level_res, ipix_res = uniq_to_level_ipix(level_ipix_to_uniq(level, ipix))
+    assert np.all(level_res == level) & np.all(ipix_res == ipix)
 
 
 def test_nside_to_pixel_area():


### PR DESCRIPTION
Following astropy/astropy-healpix#91 and astropy/regions#219 I moved the utils functions from MOCPy to here. These concern the translation of uniq number referring to a specific HEALPix cell to its order/pixel index.

I use the name `level` as a replacement for order because for the moment order refers to the HEALPix scheme used (ring, nested, XY).

So the methods added are `levelipix_to_uniq`, `uniq_to_levelipix` and I also added the methods `nside_to_level` and `level_to_nside` (the last one was already here but not accessible from the user API. I think it is useful to add it to the API because for example, with MOCPy we are more thinking in terms of level/order than nside and I usually do a nside=(1 << order) operation when instanciating a new HEALPix object in MOCPy. Having a function level_to_nside would be better I think for the visibility, what do you think ?).

Thanks for the review.