### PR TITLE
Fix bilinear interpolation of invalid values

### DIFF
--- a/astropy_healpix/tests/test_core.py
+++ b/astropy_healpix/tests/test_core.py
@@ -242,6 +242,13 @@ def test_interpolate_bilinear_invalid():
                                     values, order='banana')
     assert exc.value.args[0] == "order must be 'nested' or 'ring'"
 
+    result = interpolate_bilinear_lonlat([0, np.nan] * u.deg,
+                                         [0, np.nan] * u.deg, values,
+                                         order='nested')
+    assert result.shape == (2,)
+    assert result[0] == 1
+    assert np.isnan(result[1])
+
 
 def test_interpolate_bilinear_lonlat_shape():
 

--- a/cextern/astrometry.net/healpix.c
+++ b/cextern/astrometry.net/healpix.c
@@ -66,6 +66,9 @@ Const int64_t healpixl_xy_to_nested(int64_t hp, int Nside) {
     int i;
     int64_t ns2 = (int64_t)Nside * (int64_t)Nside;
 
+    if (hp < 0 || Nside < 0)
+        return -1;
+
     healpixl_decompose_xy(hp, &bighp, &x, &y, Nside);
     if (!is_power_of_two(Nside)) {
         fprintf(stderr, "healpix_xy_to_nested: Nside must be a power of two.\n");
@@ -93,6 +96,8 @@ Const int64_t healpixl_nested_to_xy(int64_t hp, int Nside) {
     int64_t index;
     int64_t ns2 = (int64_t)Nside * (int64_t)Nside;
     int i;
+    if (hp < 0 || Nside < 0)
+        return -1;
     if (!is_power_of_two(Nside)) {
         fprintf(stderr, "healpix_xy_to_nested: Nside must be a power of two.\n");
         return -1;
@@ -178,7 +183,9 @@ Const int64_t healpixl_ring_to_xy(int64_t ring, int Nside) {
     int bighp, x, y;
     int ringind, longind;
     healpixl_decompose_ring(ring, Nside, &ringind, &longind);
-    if (ringind <= Nside) {
+    if (ring < 0 || Nside < 0) {
+        return -1;
+    } else if (ringind <= Nside) {
         int64_t ind;
         int v;
         int F1;
@@ -294,7 +301,7 @@ Const int64_t healpixl_xy_to_ring(int64_t hp, int Nside) {
      */
     // this probably can't happen...
     if ((ring < 1) || (ring >= 4L*Nside)) {
-        fprintf(stderr, "Invalid ring index: %i %i\n", ring, 4*Nside);
+        //fprintf(stderr, "Invalid ring index: %i %i\n", ring, 4*Nside);
         return -1;
     }
     if (ring <= Nside) {


### PR DESCRIPTION
Bilinear interpolation on invalid values (e.g. when calling
`reproject.reproject_from_healpix` where some values fall outside
the projection) should return NAN instead of printing to stderr
and raising an exception.

Before this patch, the [example in the docs for `ligo.skymap.plot.allsky`](https://lscsoft.docs.ligo.org/ligo.skymap/ligo/skymap/plot/allsky.html#example) was
failing with this output:

```
Invalid ring index: -537391105 4096
Invalid ring index: -537391105 4096
... repeated a few tens of thousands of times
Traceback (most recent call last):
  File "./test.py", line 34, in <module>
    ax.imshow_hpx(url, cmap='cylon')
  File "/Users/lpsinger/src/ligo.skymap/venv/lib/python3.7/site-packages/ligo/skymap/plot/allsky.py", line 401, in imshow_hpx
    nested=nested, field=field, smooth=smooth)
  File "/Users/lpsinger/src/ligo.skymap/venv/lib/python3.7/site-packages/ligo/skymap/plot/allsky.py", line 309, in _reproject_hpx
    field=field)
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/site-packages/reproject/healpix/high_level.py", line 73, in reproject_from_healpix
    order=order, nested=nested)
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/site-packages/reproject/healpix/core.py", line 84, in healpix_to_image
    data = hp.interpolate_bilinear_lonlat(lon_in, lat_in, healpix_data)
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/site-packages/astropy_healpix/high_level.py", line 201, in interpolate_bilinear_lonlat
    return interpolate_bilinear_lonlat(lon, lat, values, order=self.order)
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/site-packages/astropy_healpix/core.py", line 413, in interpolate_bilinear_lonlat
    values = values[indices]
IndexError: index -2199022206976 is out of bounds for axis 1 with size 12582912
```

This was caused by a general lack of input validation and invalid
value propagation throughout the C library.

The expected output is shown below.

![test](https://user-images.githubusercontent.com/728407/45185837-89b34380-b1f9-11e8-9663-32c53f3cdc2f.png)
