### PR TITLE
Test fails in master

### DIFF
--- a/astropy_healpix/tests/test_healpy.py
+++ b/astropy_healpix/tests/test_healpy.py
@@ -206,7 +206,11 @@ def test_boundaries_shape():
     assert b1.shape == b2.shape
 
 
-@given(vectors=arrays(float, (3,), elements=floats(-1, 1)),
+def not_at_origin(vec):
+    return np.linalg.norm(vec) > 0
+
+
+@given(vectors=arrays(float, (3,), elements=floats(-1, 1)).filter(not_at_origin),
        lonlat=booleans(), ndim=integers(0, 4))
 @settings(max_examples=500, derandomize=True)
 def test_vec2ang(vectors, lonlat, ndim):


### PR DESCRIPTION
I was looking at https://travis-ci.org/astropy/astropy-healpix/builds/425328133 for #105 and saw some fails. Actually I think they are unrelated to that PR and will show up for all PRs (cc @bmatthieu3 and @lpsinger)

E.g. `test_vec2ang` fails here:
https://travis-ci.org/astropy/astropy-healpix/jobs/425328140#L1119

And `test_uniq_to_levelipix` fails here:
https://travis-ci.org/astropy/astropy-healpix/jobs/425328145#L1220

And the style check build also fails here:
https://travis-ci.org/astropy/astropy-healpix/jobs/425328147#L860

@bmatthieu3 and @lpsinger - if you have time to fix those, please send a PR. Otherwise I can do it tomorrow evening.