### PR TITLE
Replace deprecated np.asscalar with ndarray.item

### DIFF
--- a/astropy_healpix/core.py
+++ b/astropy_healpix/core.py
@@ -38,9 +38,9 @@ def _restore_shape(*args, **kwargs):
             return args[0].reshape(shape)
     else:
         if len(args) > 1:
-            return [np.asscalar(arg) for arg in args]
+            return [arg.item() for arg in args]
         else:
-            return np.asscalar(args[0])
+            return args[0].item()
 
 
 def _validate_order(order):

--- a/astropy_healpix/healpy.py
+++ b/astropy_healpix/healpy.py
@@ -121,8 +121,8 @@ def vec2pix(nside, x, y, z, nest=False):
     theta, phi = vec2ang(np.transpose([x, y, z]))
     # hp.vec2ang() returns raveled arrays, which are 1D.
     if np.isscalar(x):
-        theta = np.asscalar(theta)
-        phi = np.asscalar(phi)
+        theta = theta.item()
+        phi = phi.item()
     else:
         shape = np.shape(x)
         theta = theta.reshape(shape)


### PR DESCRIPTION
l`np.asscalar` was deprecated in Numpy 1.16. Since the unit tests
treat deprecation warnings as errors, we have to fix this in order
for the unit tests to pass with Numpy >= 1.16.

Fixes #115.