### PR TITLE
Remove old unused helper functions

### DIFF
--- a/astropy_healpix/core.py
+++ b/astropy_healpix/core.py
@@ -28,20 +28,6 @@ __all__ = [
 ]
 
 
-def _restore_shape(*args, **kwargs):
-    shape = kwargs['shape']
-    if shape:
-        if len(args) > 1:
-            return [arg.reshape(shape) for arg in args]
-        else:
-            return args[0].reshape(shape)
-    else:
-        if len(args) > 1:
-            return [arg.item() for arg in args]
-        else:
-            return args[0].item()
-
-
 def _validate_order(order):
     # We also support upper-case, to support directly the values
     # ORDERING = {'RING', 'NESTED'} in FITS headers
@@ -52,12 +38,6 @@ def _validate_order(order):
         return 'ring'
     else:
         raise ValueError("order must be 'nested' or 'ring'")
-
-
-def _validate_healpix_index(label, healpix_index, nside):
-    npix = nside_to_npix(nside)
-    if np.any((healpix_index < 0) | (healpix_index > npix - 1)):
-        raise ValueError(f'{label} must be in the range [0:{npix}]')
 
 
 def _validate_offset(label, offset):


### PR DESCRIPTION
This PR removes the old and unused `_restore_shape` and `_validate_healpix_index` helper functions. I just noticed them in the code coverage report.

There is the question if we should validate `healpix_index` or not, and if it's not in the range what to do. (the `_restore_shape` just isn't needed any more since @lpsinger introduced ufuncs)

Currently the check is here:
https://github.com/astropy/astropy-healpix/commit/87bf0c1990825f51ac4fa5a289461b50608ddcd0#diff-d16b2ef86578243bf558a029cbcd7fdeR33
and what we get is `NaN` in the output and a RunTimeWarning:
```
In [5]: astropy_healpix.healpix_to_lonlat(99, 1)                                                                                                                                                 
/Users/deil/work/code/astropy-healpix/astropy_healpix/core.py:376: RuntimeWarning: invalid value encountered in healpix_ring_to_lonlat
  lon, lat = func(healpix_index, nside, dx, dy)
Out[5]: (<Longitude nan rad>, <Latitude nan rad>)
```
Equivalent to what healpy does.

Except for the uniq ipix conversion functions, there we currently raise a ValueError when it's out of range:
https://github.com/astropy/astropy-healpix/pull/105/files#diff-97d939e5cd1cbdc8cccf59e6a607ac25R71

Probably we should be uniform, and not emit a warning and give an output in one case, and raise an error in the other case?

That's a usability question and probably the more important one. But there's also the performance concern - doing if / else for every pixel in the hot for loop is probably a large slowdown?

@lpsinger @astrofrog @bmatthieu3 - Thoughts?