### PR TITLE
Fix floating point unit test failures on i386

### DIFF
--- a/astropy_healpix/tests/test_healpy.py
+++ b/astropy_healpix/tests/test_healpy.py
@@ -23,14 +23,14 @@ NSIDE_VALUES = [2 ** n for n in range(1, 6)]
 def test_nside2pixarea(nside, degrees):
     actual = hp_compat.nside2pixarea(nside=nside, degrees=degrees)
     expected = hp.nside2pixarea(nside=nside, degrees=degrees)
-    assert_equal(actual, expected)
+    assert_allclose(actual, expected)
 
 
 @pytest.mark.parametrize(('nside', 'arcmin'), product(NSIDE_VALUES, (False, True)))
 def test_nside2resol(nside, arcmin):
     actual = hp_compat.nside2resol(nside=nside, arcmin=arcmin)
     expected = hp.nside2resol(nside=nside, arcmin=arcmin)
-    assert_equal(actual, expected)
+    assert_allclose(actual, expected)
 
 
 @pytest.mark.parametrize('nside', NSIDE_VALUES)


### PR DESCRIPTION
The following unit test failures on i386 were discovered by the Debian reproducible builds project (https://tests.reproducible-builds.org/debian/rb-pkg/unstable/i386/astropy-healpix.html):

```
=================================== FAILURES ===================================
__________________________ test_nside2pixarea[2-True] __________________________

nside = 2, degrees = True

    @pytest.mark.parametrize(('nside', 'degrees'), product(NSIDE_VALUES, (False, True)))
    def test_nside2pixarea(nside, degrees):
        actual = hp_compat.nside2pixarea(nside=nside, degrees=degrees)
        expected = hp.nside2pixarea(nside=nside, degrees=degrees)
>       assert_equal(actual, expected)
E       AssertionError:
E       Items are not equal:
E        ACTUAL: 859.43669269623479
E        DESIRED: 859.43669269623467

astropy_healpix/tests/test_healpy.py:26: AssertionError
__________________________ test_nside2pixarea[4-True] __________________________

nside = 4, degrees = True

    @pytest.mark.parametrize(('nside', 'degrees'), product(NSIDE_VALUES, (False, True)))
    def test_nside2pixarea(nside, degrees):
        actual = hp_compat.nside2pixarea(nside=nside, degrees=degrees)
        expected = hp.nside2pixarea(nside=nside, degrees=degrees)
>       assert_equal(actual, expected)
E       AssertionError:
E       Items are not equal:
E        ACTUAL: 214.8591731740587
E        DESIRED: 214.85917317405867

astropy_healpix/tests/test_healpy.py:26: AssertionError
__________________________ test_nside2pixarea[8-True] __________________________

nside = 8, degrees = True

    @pytest.mark.parametrize(('nside', 'degrees'), product(NSIDE_VALUES, (False, True)))
    def test_nside2pixarea(nside, degrees):
        actual = hp_compat.nside2pixarea(nside=nside, degrees=degrees)
        expected = hp.nside2pixarea(nside=nside, degrees=degrees)
>       assert_equal(actual, expected)
E       AssertionError:
E       Items are not equal:
E        ACTUAL: 53.714793293514674
E        DESIRED: 53.714793293514667

astropy_healpix/tests/test_healpy.py:26: AssertionError
_________________________ test_nside2pixarea[16-True] __________________________

nside = 16, degrees = True

    @pytest.mark.parametrize(('nside', 'degrees'), product(NSIDE_VALUES, (False, True)))
    def test_nside2pixarea(nside, degrees):
        actual = hp_compat.nside2pixarea(nside=nside, degrees=degrees)
        expected = hp.nside2pixarea(nside=nside, degrees=degrees)
>       assert_equal(actual, expected)
E       AssertionError:
E       Items are not equal:
E        ACTUAL: 13.428698323378669
E        DESIRED: 13.428698323378667

astropy_healpix/tests/test_healpy.py:26: AssertionError
_________________________ test_nside2pixarea[32-True] __________________________

nside = 32, degrees = True

    @pytest.mark.parametrize(('nside', 'degrees'), product(NSIDE_VALUES, (False, True)))
    def test_nside2pixarea(nside, degrees):
        actual = hp_compat.nside2pixarea(nside=nside, degrees=degrees)
        expected = hp.nside2pixarea(nside=nside, degrees=degrees)
>       assert_equal(actual, expected)
E       AssertionError:
E       Items are not equal:
E        ACTUAL: 3.3571745808446671
E        DESIRED: 3.3571745808446667

astropy_healpix/tests/test_healpy.py:26: AssertionError
___________________________ test_nside2resol[2-True] ___________________________

nside = 2, arcmin = True

    @pytest.mark.parametrize(('nside', 'arcmin'), product(NSIDE_VALUES, (False, True)))
    def test_nside2resol(nside, arcmin):
        actual = hp_compat.nside2resol(nside=nside, arcmin=arcmin)
        expected = hp.nside2resol(nside=nside, arcmin=arcmin)
>       assert_equal(actual, expected)
E       AssertionError:
E       Items are not equal:
E        ACTUAL: 1758.9690428505119
E        DESIRED: 1758.9690428505116

astropy_healpix/tests/test_healpy.py:33: AssertionError
___________________________ test_nside2resol[4-True] ___________________________

nside = 4, arcmin = True

    @pytest.mark.parametrize(('nside', 'arcmin'), product(NSIDE_VALUES, (False, True)))
    def test_nside2resol(nside, arcmin):
        actual = hp_compat.nside2resol(nside=nside, arcmin=arcmin)
        expected = hp.nside2resol(nside=nside, arcmin=arcmin)
>       assert_equal(actual, expected)
E       AssertionError:
E       Items are not equal:
E        ACTUAL: 879.48452142525593
E        DESIRED: 879.48452142525582

astropy_healpix/tests/test_healpy.py:33: AssertionError
___________________________ test_nside2resol[8-True] ___________________________

nside = 8, arcmin = True

    @pytest.mark.parametrize(('nside', 'arcmin'), product(NSIDE_VALUES, (False, True)))
    def test_nside2resol(nside, arcmin):
        actual = hp_compat.nside2resol(nside=nside, arcmin=arcmin)
        expected = hp.nside2resol(nside=nside, arcmin=arcmin)
>       assert_equal(actual, expected)
E       AssertionError:
E       Items are not equal:
E        ACTUAL: 439.74226071262797
E        DESIRED: 439.74226071262791

astropy_healpix/tests/test_healpy.py:33: AssertionError
__________________________ test_nside2resol[16-True] ___________________________

nside = 16, arcmin = True

    @pytest.mark.parametrize(('nside', 'arcmin'), product(NSIDE_VALUES, (False, True)))
    def test_nside2resol(nside, arcmin):
        actual = hp_compat.nside2resol(nside=nside, arcmin=arcmin)
        expected = hp.nside2resol(nside=nside, arcmin=arcmin)
>       assert_equal(actual, expected)
E       AssertionError:
E       Items are not equal:
E        ACTUAL: 219.87113035631398
E        DESIRED: 219.87113035631396

astropy_healpix/tests/test_healpy.py:33: AssertionError
__________________________ test_nside2resol[32-True] ___________________________

nside = 32, arcmin = True

    @pytest.mark.parametrize(('nside', 'arcmin'), product(NSIDE_VALUES, (False, True)))
    def test_nside2resol(nside, arcmin):
        actual = hp_compat.nside2resol(nside=nside, arcmin=arcmin)
        expected = hp.nside2resol(nside=nside, arcmin=arcmin)
>       assert_equal(actual, expected)
E       AssertionError:
E       Items are not equal:
E        ACTUAL: 109.93556517815699
E        DESIRED: 109.93556517815698

astropy_healpix/tests/test_healpy.py:33: AssertionError
==================== 10 failed, 106 passed in 18.36 seconds ====================
```