### PR TITLE
Export boundaries_lonlat in __all__

### DIFF
--- a/astropy_healpix/core.py
+++ b/astropy_healpix/core.py
@@ -24,6 +24,7 @@ __all__ = [
     'healpix_to_xyz',
     'bilinear_interpolation_weights',
     'interpolate_bilinear_lonlat',
+    'boundaries_lonlat',
     'neighbours',
 ]
 


### PR DESCRIPTION
There is really no reason for it not to be exported. I was looking for it in order to plot boundaries of a set of HEALPix tiles of mixed resolutions, and was surprised to find that I had to directly import it from `astropy_healpix.core`.