### PR TITLE
Update gitignore from Astropy package template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,12 +29,20 @@ docs/_build
 # Pycharm editor project files
 .idea
 
+# Floobits project files
+.floo
+.flooignore
+
+# Visual Studio Code project files
+.vscode
+
 # Packages/installer info
 *.egg
 *.egg-info
 dist
 build
 eggs
+.eggs
 parts
 bin
 var
@@ -48,6 +56,10 @@ distribute-*.tar.gz
 .tox
 .*.sw[op]
 *~
+.project
+.pydevproject
+.settings
+pip-wheel-metadata/
 
 # Mac OSX
 .DS_Store
@@ -60,6 +72,3 @@ astropy_healpix/core_cython.c
 v
 
 .hypothesis
-.eggs
-
-pip-wheel-metadata/


### PR DESCRIPTION
This brings in gitignores for VS Code project directories, among other things.