### PR TITLE
Disable Azure pipelines for Python 3.6

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,7 @@ Changes
 - The ``frame`` keyword argument for the high-level ``HEALPix`` class may now
   be a frame name, frame instance, or frame class. [#156]
 - On instantiation, the ``HEALPix`` class checks the ``order`` argument. [#162]
+- Drop support for Python 3.6, which has passed end-of-life. [#166]
 
 0.6 (2021-03-10)
 ================

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,5 +1,6 @@
 variables:
   CIBW_BUILD: cp37-* cp38-* cp39-*
+  CIBW_SKIP: *musllinux*
 
 resources:
   repositories:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,5 +1,5 @@
 variables:
-  CIBW_BUILD: cp36-* cp37-* cp38-* cp39-*
+  CIBW_BUILD: cp37-* cp38-* cp39-*
 
 resources:
   repositories:
@@ -28,22 +28,18 @@ jobs:
 
     - linux: codestyle
 
-    - macos: py36-test-cov
     - macos: py37-test-cov
     - macos: py38-test-cov
     - macos: py39-test-cov
 
-    - linux: py36-test-cov
     - linux: py37-test-cov
     - linux: py38-test-cov
     - linux: py39-test-cov
 
-    - linux32: py36-test-cov
     - linux32: py37-test-cov
     - linux32: py38-test-cov
     - linux32: py39-test-cov
 
-    - windows: py36-test-cov
     - windows: py37-test-cov
     - windows: py38-test-cov
     - windows: py39-test-cov

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -14,7 +14,7 @@ Dependencies
 Required dependencies
 ---------------------
 
-The **astropy-healpix** package works with Python 3.6 and later (on Linux, MacOS
+The **astropy-healpix** package works with Python 3.7 and later (on Linux, MacOS
 and Windows), and requires the following dependencies:
 
 * `Numpy <http://www.numpy.org>`__ 1.11 or later

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -11,7 +11,7 @@ channels:
   - conda-forge
 
 dependencies:
-  - python==3.6
+  - python==3.7
   - pip
   - ipython
   - numpy

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,7 @@ github_project = astropy/astropy-healpix
 [options]
 zip_safe = False
 packages = find:
-python_requires = >=3.6
+python_requires = >=3.7
 setup_requires = setuptools_scm
 install_requires =
     numpy


### PR DESCRIPTION
Python 3.6 is apparently no longer supported. That's fine, because 3.6 hits end of life in a few weeks.