### PR TITLE
MNT: Stop using deprecated astropy.tests functions

### DIFF
--- a/astropy_healpix/conftest.py
+++ b/astropy_healpix/conftest.py
@@ -7,19 +7,11 @@ import os
 
 import numpy as np
 
-from astropy.version import version as astropy_version
-
-# For Astropy 3.0 and later, we can use the standalone pytest plugin
-if astropy_version < '3.0':
-    from astropy.tests.pytest_plugins import *  # noqa
-    del pytest_report_header
+try:
+    from pytest_astropy_header.display import PYTEST_HEADER_MODULES, TESTED_VERSIONS
     ASTROPY_HEADER = True
-else:
-    try:
-        from pytest_astropy_header.display import PYTEST_HEADER_MODULES, TESTED_VERSIONS
-        ASTROPY_HEADER = True
-    except ImportError:
-        ASTROPY_HEADER = False
+except ImportError:
+    ASTROPY_HEADER = False
 
 
 def pytest_configure(config):
@@ -45,6 +37,3 @@ def pytest_configure(config):
         # On older versions of Numpy, the unrecognized 'legacy' option will
         # raise a TypeError.
         pass
-
-from astropy.tests.helper import enable_deprecations_as_exceptions  # noqa
-enable_deprecations_as_exceptions()

--- a/astropy_healpix/setup_package.py
+++ b/astropy_healpix/setup_package.py
@@ -2,7 +2,7 @@
 
 import os
 
-from distutils.core import Extension
+from setuptools import Extension
 
 import numpy as np
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,7 @@ python_requires = >=3.7
 setup_requires = setuptools_scm
 install_requires =
     numpy
-    astropy
+    astropy>=3
 
 [options.extras_require]
 test =


### PR DESCRIPTION
This pull request is to remove soon to be deprecated code; also see astropy/astropy#12633 . Also stop using `distutils` and officially set minversion for `astropy`.