### PR TITLE
Move cibuildwheel setup to pyproject.toml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,3 @@ jobs:
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish.yml@v1
     secrets:
       pypi_token: ${{ secrets.pypi_token }}
-    env:
-      CIBW_SKIP: '*-musllinux_*'
-      CIBW_BUILD: 'cp37-* cp38-* cp39-* cp310-*'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,3 +7,6 @@ requires = ["setuptools",
             "oldest-supported-numpy"]
 
 build-backend = 'setuptools.build_meta'
+
+[tool.cibuildwheel]
+skip = "*-musllinux_*"


### PR DESCRIPTION
Should also fix this error:

```
The workflow is not valid. .github/workflows/publish.yml (Line: 13, Col: 5): Unexpected value 'env'
```