### PR TITLE
TST: Update URL for Scientific Python nightlies

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -65,7 +65,7 @@ extras =
     alldeps: all
 
 commands =
-    devdeps: pip install -U --pre --only-binary :all: -i https://pypi.anaconda.org/scipy-wheels-nightly/simple numpy
+    devdeps: pip install -U --pre --only-binary :all: -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy
     pip freeze
     !cov: pytest --pyargs astropy_healpix {toxinidir}/docs {posargs}
     cov: pytest --pyargs astropy_healpix {toxinidir}/docs --cov astropy_healpix --cov-config={toxinidir}/setup.cfg {posargs}


### PR DESCRIPTION
Scientific Python packages have moved their nightly wheels to a new location. xref astropy/astropy#14869

This is an automated update made by the `batchpr` tool :robot: - feel free to close if it doesn't look good! You can report issues to @pllim.