### PR TITLE
Remove old placeholder workaround

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -53,7 +53,7 @@ jobs:
             toxenv: py311-test-alldeps-predeps
 
           - name: Python 3.9 with oldest supported version of all dependencies
-            os: ubuntu-20.04
+            os: ubuntu-22.04
             python: 3.9
             toxenv: py39-test-oldestdeps
 

--- a/astropy_healpix/_core.c
+++ b/astropy_healpix/_core.c
@@ -1,23 +1,3 @@
-/* FIXME:
- * The Numpy C-API defines PyArrayDescr_Type as:
- *
- *   #define PyArrayDescr_Type (*(PyTypeObject *)PyArray_API[3])
- *
- * and then in some places we need to take its address, &PyArrayDescr_Type.
- * This is fine in GCC 10 and Clang, but earlier versions of GCC complain:
- *
- *   error: dereferencing pointer to incomplete type 'PyTypeObject'
- *   {aka 'struct _typeobject'}
- *
- * As a workaround, provide a faux forward declaration for PyTypeObject.
- * See https://github.com/numpy/numpy/issues/16970.
- *
- * Drop this when supporting gcc < 10 becomes irrelevant.
- */
-struct _typeobject {
-    int _placeholder;
-};
-
 #include <Python.h>
 #include <numpy/arrayobject.h>
 #include <numpy/ufuncobject.h>


### PR DESCRIPTION
Since gcc 10 is no longer supported (https://gcc.gnu.org/gcc-10/), and this workaround is causing issues with packaging on conda-forge (https://github.com/conda-forge/astropy-healpix-feedstock/pull/32), remove the workaround.

I had to bump the Ubuntu version in the oldestdeps test to pick up a newer version of gcc (gcc-9 > gcc-11)