### PR TITLE
Unpin Numpy version for building wheels

### DIFF
--- a/astropy_healpix/setup_package.py
+++ b/astropy_healpix/setup_package.py
@@ -39,6 +39,7 @@ def get_extensions():
         extra_compile_args=['-O2'],
         py_limited_api=True,
         define_macros=[('Py_LIMITED_API', 0x03090000),
+                       ('NPY_TARGET_VERSION', 'NPY_1_19_API_VERSION'),
                        ('NPY_NO_DEPRECATED_API', 'NPY_1_19_API_VERSION')])
 
     return [extension]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,6 @@
 
 requires = ["setuptools>=42.0.0",
             "setuptools_scm",
-            "wheel",
             "extension-helpers",
             "numpy>=1.25,<2"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = ["setuptools>=42.0.0",
             "setuptools_scm",
             "wheel",
             "extension-helpers",
-            "numpy==1.25.1"]
+            "numpy>=1.25,<2"]
 
 build-backend = 'setuptools.build_meta'
 


### PR DESCRIPTION
Allow using any version of Numpy between 1.25 and 2. This will allow us to use the latest release of Numpy on PyPI and take advantage of prebuilt wheels for more platforms and architectures.

Use the new `NPY_TARGET_VERSION` macro to peform a backward-compatible supporting versions of Numpy as old as 1.19.