### PR TITLE
Build against Numpy 2.0.0rc1 or later

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,11 +27,8 @@ jobs:
         - cp3*-macosx_arm64
         - cp3*-manylinux_aarch64
 
-      # Developer wheels (use Numpy dev to build)
+      # Developer wheels
       upload_to_anaconda: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') }}
       anaconda_user: astropy
       anaconda_package: astropy-healpix
       anaconda_keep_n_latest: 10
-      env: |
-        CIBW_BEFORE_BUILD: '${{ ((github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && 'pip install --pre --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple setuptools setuptools_scm numpy>=0.0dev0 extension-helpers') || '' }}'
-        CIBW_BUILD_FRONTEND: '${{ ((github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && 'pip; args: --no-build-isolation') || 'build' }}'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 requires = ["setuptools>=42.0.0",
             "setuptools_scm",
             "extension-helpers",
-            "numpy>=1.25,<2"]
+            "numpy>=2.0.0rc1"]
 
 build-backend = 'setuptools.build_meta'
 


### PR DESCRIPTION
We need to release new wheels of reproject compiled against Numpy 2.0.0rc1 ahead of the final Numpy 2.0.0 release, so this PR updates the build-time dependencies and also simplifies the nightly wheels configuration.