### PR TITLE
BUG: fix compatibility with numpy 2.0.0 (copy semantics)

### DIFF
--- a/astropy_healpix/core.py
+++ b/astropy_healpix/core.py
@@ -28,6 +28,8 @@ __all__ = [
     'neighbours',
 ]
 
+_NUMPY_COPY_IF_NEEDED = False if np.__version__.startswith("1.") else None
+
 
 def _validate_order(order):
     # We also support upper-case, to support directly the values
@@ -369,8 +371,8 @@ def healpix_to_lonlat(healpix_index, nside, dx=None, dy=None, order='ring'):
 
     lon, lat = func(healpix_index, nside, dx, dy)
 
-    lon = Longitude(lon, unit=u.rad, copy=False)
-    lat = Latitude(lat, unit=u.rad, copy=False)
+    lon = Longitude(lon, unit=u.rad, copy=_NUMPY_COPY_IF_NEEDED)
+    lat = Latitude(lat, unit=u.rad, copy=_NUMPY_COPY_IF_NEEDED)
 
     return lon, lat
 


### PR DESCRIPTION
Unblocks #214

This isn't the only place where `copy=False` is used in the code base, but that's the only one that causes tests to fail, looking at [example logs](https://github.com/astropy/astropy-healpix/actions/runs/8568206064/job/23481585092?pr=214), so the fix is minimal. If other call sites with `copy=False` raise errors with numpy 2.0 in the future they could be adjusted similarly.