### PR TITLE
Don't build wheels for PyPy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ requires = ["setuptools>=42.0.0",
 build-backend = 'setuptools.build_meta'
 
 [tool.cibuildwheel]
-skip = "*-musllinux_* pp310*"
+skip = "*-musllinux_* pp*"
 
 [tool.cibuildwheel.macos]
 archs = ["x86_64", "universal2"]


### PR DESCRIPTION
PyPy is probably not long for this world; see
https://github.com/mesonbuild/meson-python/pull/626#issuecomment-2111018667.

Fixes #216.