### PR TITLE
Document that neighbours function may return -1

### DIFF
--- a/astropy_healpix/core.py
+++ b/astropy_healpix/core.py
@@ -647,6 +647,13 @@ def neighbours(healpix_index, nside, order='ring'):
         one extra dimension compared to ``healpix_index`` - the first dimension -
         which is set to 8. For example if healpix_index has shape (2, 3),
         ``neigh`` has shape (8, 2, 3).
+
+    Notes
+    -----
+    Some HEALPix pixels do not have all 8 neighbours. In these cases, the
+    corresponding entry in the returned array has the value of -1 and Numpy
+    may print an invalid value warning. To suppress the warning, use
+    :class:`numpy.errstate`.
     """
 
     _validate_nside(nside)

--- a/astropy_healpix/high_level.py
+++ b/astropy_healpix/high_level.py
@@ -400,6 +400,13 @@ class HEALPix:
             one extra dimension compared to ``healpix_index`` - the first dimension -
             which is set to 8. For example if healpix_index has shape (2, 3),
             ``neigh`` has shape (8, 2, 3).
+
+        Notes
+        -----
+        Some HEALPix pixels do not have all 8 neighbours. In these cases, the
+        corresponding entry in the returned array has the value of -1 and Numpy
+        may print an invalid value warning. To suppress the warning, use
+        :class:`numpy.errstate`.
         """
         return neighbours(healpix_index, self.nside, order=self.order)
 


### PR DESCRIPTION
Some HEALPix pixels do not have all 8 neighbours. In these cases, the corresponding entry in the returned array has the value of -1 and Numpy may print an invalid value warning. To suppress the warning, use `numpy.errstate`.

Fixes #217.