### PR TITLE
Add sphinx.configuration variable to fix Sphinx build

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -14,3 +14,6 @@ python:
         - all
 
 formats: []
+
+sphinx:
+  configuration: docs/conf.py


### PR DESCRIPTION
See https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/