### PR TITLE
Fix broken unit tests in test_healpy

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -42,10 +42,10 @@ jobs:
             python: '3.11'
             toxenv: py311-test-alldeps
 
-          - name: Windows - Python 3.11 with all optional dependencies
+          - name: Windows - Python 3.11 with minimal dependencies
             os: windows-latest
             python: '3.11'
-            toxenv: py311-test-alldeps
+            toxenv: py311-test
 
           - name: Python 3.12 with all optional dependencies and pre-releases
             os: ubuntu-latest

--- a/tox.ini
+++ b/tox.ini
@@ -50,6 +50,9 @@ deps =
     devdeps: numpy>=0.0.dev0
     devdeps: pyerfa>=0.0.dev0
     devdeps: astropy>=0.0.dev0
+    devdeps: healpy
+
+    alldeps: healpy
 
 # The following indicates which extras_require from setup.cfg will be installed
 extras =


### PR DESCRIPTION
- Fix test_vec2ang near poles. Compare the angular separation between the desired and actual coordinates rather than the coordinates themselves to avoid comparing meaningless values of longitude near the poles.
- Fix test_vec2pix near pixel boundaries. Don't test the return value on pixel boundaries; here, ipix is ambiguous.
- Add healpy to test dependencies so that test_healpy is run in the GitHub Actions pipeline.

Fixes #183.
