### PR TITLE
Add back predeps tox env

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{310,311,312,313}-test{,-alldeps,-devdeps}{,-cov}
+    py{310,311,312,313}-test{,-alldeps,-devdeps,-predeps}{,-cov}
     build_docs
     linkcheck
     codestyle


### PR DESCRIPTION
It is still used in the GH Actions workflow.