### PR TITLE
Check interpolate_bilinear_lonlat inputs for invalid values

### DIFF
--- a/astropy_healpix/_core.c
+++ b/astropy_healpix/_core.c
@@ -258,11 +258,20 @@ static void bilinear_interpolation_weights_loop(
         double weights[4];
         int j;
 
-        interpolate_weights(lon, lat, indices, weights, nside);
-        for (j = 0; j < 4; j ++)
-        {
-            *(int64_t *) &args[3 + j][i * steps[3 + j]] = indices[j];
-            *(double *)  &args[7 + j][i * steps[7 + j]] = weights[j];
+        if (isfinite(lon) && isfinite(lat)) {
+            interpolate_weights(lon, lat, indices, weights, nside);
+            for (j = 0; j < 4; j ++)
+            {
+                *(int64_t *) &args[3 + j][i * steps[3 + j]] = indices[j];
+                *(double *)  &args[7 + j][i * steps[7 + j]] = weights[j];
+            }
+        } else {
+            for (j = 0; j < 4; j ++)
+            {
+                *(int64_t *) &args[3 + j][i * steps[3 + j]] = INVALID_INDEX;
+                *(double *)  &args[7 + j][i * steps[7 + j]] = NPY_NAN;
+            }
+            _npy_set_floatstatus_invalid();
         }
     }
 }

--- a/astropy_healpix/tests/test_core.py
+++ b/astropy_healpix/tests/test_core.py
@@ -211,8 +211,9 @@ def test_lonlat_to_healpix_shape():
 
 def test_lonlat_to_healpix_invalid():
     """Check that if we pass NaN values for example, the index is set to -1"""
-    ipix = lonlat_to_healpix(np.nan * u.deg, np.nan * u.deg,
-                             nside=1, order='nested')
+    with pytest.warns(RuntimeWarning, match='invalid value'):
+        ipix = lonlat_to_healpix(np.nan * u.deg, np.nan * u.deg,
+                                 nside=1, order='nested')
     assert ipix == -1
 
 
@@ -279,9 +280,10 @@ def test_interpolate_bilinear_invalid():
                                     values, order='banana')
     assert exc.value.args[0] == "order must be 'nested' or 'ring'"
 
-    result = interpolate_bilinear_lonlat([0, np.nan] * u.deg,
-                                         [0, np.nan] * u.deg, values,
-                                         order='nested')
+    with pytest.warns(RuntimeWarning, match='invalid value'):
+        result = interpolate_bilinear_lonlat([0, np.nan] * u.deg,
+                                             [0, np.nan] * u.deg, values,
+                                             order='nested')
     assert result.shape == (2,)
     assert result[0] == 1
     assert np.isnan(result[1])


### PR DESCRIPTION
This is found to fix abort errors that occurred on macOS x86_64 when running the unit tests for the Conda packages. See https://github.com/conda-forge/astropy-healpix-feedstock/pull/41.

This might indicate that some of the Conda builds have assertions disabled via the `NDEBUG` preprocessor macro, and some have them enabled, inconsistently.

Without this patch, any number of assertions should have been tripped. For example, this one:
https://github.com/astropy/astropy-healpix/blob/v1.1.1/cextern/astrometry.net/healpix.c#L742