### PR TITLE
Remove explicit limited API options which are no longer needed

### DIFF
--- a/astropy_healpix/setup_package.py
+++ b/astropy_healpix/setup_package.py
@@ -36,9 +36,7 @@ def get_extensions():
         libraries=libraries,
         language="c",
         extra_compile_args=['-O2'],
-        py_limited_api=True,
-        define_macros=[('Py_LIMITED_API', 0x030A0000),
-                       ('NPY_TARGET_VERSION', 'NPY_1_19_API_VERSION'),
+        define_macros=[('NPY_TARGET_VERSION', 'NPY_1_19_API_VERSION'),
                        ('NPY_NO_DEPRECATED_API', 'NPY_1_19_API_VERSION')])
 
     return [extension]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 
 requires = ["setuptools>=42.0.0",
             "setuptools_scm",
-            "extension-helpers",
+            "extension-helpers>=1.3,<2",
             "numpy>=2.0.0"]
 
 build-backend = 'setuptools.build_meta'


### PR DESCRIPTION
I think these are no longer needed with extension-helpers 1.3 and above