### PR TITLE
Upgrade PyPI CI publishing to use Trusted Publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,9 +17,10 @@ jobs:
     if: (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'Build wheels'))
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish.yml@a138926f6e4f9667d1306c24f24f5bdcaa01fbab  # v2.5.0
     secrets:
-      pypi_token: ${{ secrets.pypi_token }}
       anaconda_token: ${{ secrets.anaconda_token }}
     with:
+      upload_to_pypi: false
+      save_artifacts: true
       targets: |
         - cp3*-manylinux_x86_64
         - cp3*-musllinux_x86_64
@@ -35,3 +36,30 @@ jobs:
       anaconda_user: astropy
       anaconda_package: astropy-healpix
       anaconda_keep_n_latest: 10
+
+  upload:
+    permissions:
+      id-token: write
+    environment:
+      name: pypi
+      url: https://pypi.org/project/astropy-healpix
+    if: >-
+      ${{ startsWith(github.ref, 'refs/tags/v') &&
+          !endsWith(github.ref, '.dev') &&
+          (
+            github.event_name == 'push' ||
+            github.event_name == 'workflow_dispatch'
+          )
+      }}
+    name: Upload release to PyPI
+    runs-on: ubuntu-latest
+    needs: [publish]
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          merge-multiple: true
+          pattern: dist-*
+          path: dist
+      - name: Upload to PyPI
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0


### PR DESCRIPTION
- Background: https://github.com/astropy/specutils/issues/1323

Migrates PyPI publishing from a long-lived API token to [Trusted Publishing](https://docs.pypi.org/trusted-publishers/) (OIDC), motivated by recent supply chain attacks ([litellm](https://blog.pypi.org/posts/2026-04-02-incident-report-litellm-telnyx-supply-chain-attack/), [lightning](https://cybersecuritynews.com/python-package-lightning-hacked/)).

The publishing step uses [a reusable workflow](https://github.com/OpenAstronomy/github-actions-workflows/blob/v2.6.3/.github/workflows/publish.yml) from the OpenAstronomy org, and since you can't pass OIDC tokens across orgs, the workaround (documented [here](https://github-actions-workflows.openastronomy.org/en/latest/trusted_publishing.html)) is to instead set `upload_to_pypi: false` and `save_artifacts: true` then publish the stored artifact with the `pypa/gh-action-pypi` action.

- Adapted from similar PR in regions repo: https://github.com/astropy/regions/pull/661 which followed [this example](https://github.com/astropy/astropy/blob/80447a4334ba617c04d5918b66d80793f202c52e/.github/workflows/publish.yml#L77-L94) from the astropy package repo.
- :bulb: I made this repo's package build step condition consistent with the one in that repo, which was more defensive
  - It means "publish all tags starting with `v` that don't end in `.dev`, if sent via push or manual dispatch"
  - The same was done for reproject in https://github.com/astropy/reproject/pull/598

```yaml
    if: >-
      ${{ startsWith(github.ref, 'refs/tags/v') &&
          !endsWith(github.ref, '.dev') &&
          (
            github.event_name == 'push' ||
            github.event_name == 'workflow_dispatch'
          )
      }}
```

The code changes here require some further (trivial) setup on the PyPI-side. Specifically, the PyPI admin (not just maintainer) needs to register the TP on PyPI at https://pypi.org/manage/project/astropy-healpix/settings/publishing/

- Owner: `astropy`
- Repo: `astropy-healpix`
- Workflow: `publish.yml`
- Environment: `pypi`

The `pypi_token` secret should be deleted from the repo secrets and can be invalidated on PyPI too.

(Not sure who is the PyPI admin, the maintainers are listed as @lpsinger @astrofrog)