### PR TITLE
Fix off-by-one in uniq_to_level_ipix at level boundaries

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,14 @@
 Changes
 *******
 
+1.1.4 (unreleased)
+==================
+
+- Fix an off-by-one error in ``uniq_to_level_ipix`` that returned the wrong
+  level (and a negative ``ipix``) for the last pixel of levels >= 24, caused by
+  floating-point rounding in the level computation. The level is now computed
+  with exact integer arithmetic.
+
 1.1.3 (2026-01-19)
 ==================
 

--- a/astropy_healpix/core.py
+++ b/astropy_healpix/core.py
@@ -132,8 +132,14 @@ def uniq_to_level_ipix(uniq):
     """
     uniq = np.asarray(uniq, dtype=np.int64)
 
-    level = (np.log2(uniq // 4)) // 2
-    level = level.astype(np.int64)
+    # level = floor(log4(uniq)) - 1. A purely floating-point log2 mis-rounds at
+    # power-of-two boundaries (e.g. the last pixel of a level, where uniq is just
+    # below 2 ** 52), giving a level that is off by one, so refine the
+    # floating-point guess with exact integer comparisons.
+    log2 = np.floor(np.log2(uniq)).astype(np.int64)
+    log2 -= (np.int64(1) << log2) > uniq
+    log2 += (np.int64(1) << log2) <= (uniq >> np.int64(1))
+    level = (log2 >> np.int64(1)) - 1
     _validate_level(level)
 
     ipix = uniq - (1 << 2 * (level + 1))

--- a/astropy_healpix/tests/test_core.py
+++ b/astropy_healpix/tests/test_core.py
@@ -66,6 +66,17 @@ def test_uniq_to_level_ipix(level):
     assert np.all(level_res == level) & np.all(ipix_res == ipix)
 
 
+@pytest.mark.parametrize("level", [0, 5, 10, 15, 20, 22, 24, 25, 26, 27, 28, 29])
+def test_uniq_to_level_ipix_boundary(level):
+    # The last pixel of each level is the worst case for a floating-point level
+    # computation: uniq is just below a power of two, where log2 mis-rounds.
+    npix = 3 << 2 * (level + 1)
+    ipix = npix - 1
+    level_res, ipix_res = uniq_to_level_ipix(level_ipix_to_uniq(level, ipix))
+    assert level_res == level
+    assert ipix_res == ipix
+
+
 def test_nside_to_pixel_area():
     resolution = nside_to_pixel_area(256)
     assert_allclose(resolution.value, 1.5978966540475428e-05)


### PR DESCRIPTION
This PR computes the level with exact integer arithmetic preventing an issue at level boundaries.