### PR TITLE
Stack multiple parametrize decorators in unit tests

### DIFF
--- a/astropy_healpix/tests/test_core.py
+++ b/astropy_healpix/tests/test_core.py
@@ -1,6 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from itertools import product
-
 import pytest
 
 import numpy as np
@@ -382,9 +380,8 @@ def test_healpix_cone_search(order):
     assert len(indices) == 80
 
 
-@pytest.mark.parametrize(
-    ("step", "order"), list(product([1, 4, 10], ["nested", "ring"]))
-)
+@pytest.mark.parametrize("step", [1, 4, 10])
+@pytest.mark.parametrize("order", ["nested", "ring"])
 def test_boundaries_lonlat(step, order):
     lon, lat = boundaries_lonlat([10, 20, 30], step, 256, order=order)
     assert lon.shape == (3, 4 * step)

--- a/astropy_healpix/tests/test_core.py
+++ b/astropy_healpix/tests/test_core.py
@@ -382,7 +382,9 @@ def test_healpix_cone_search(order):
     assert len(indices) == 80
 
 
-@pytest.mark.parametrize(("step", "order"), product([1, 4, 10], ["nested", "ring"]))
+@pytest.mark.parametrize(
+    ("step", "order"), list(product([1, 4, 10], ["nested", "ring"]))
+)
 def test_boundaries_lonlat(step, order):
     lon, lat = boundaries_lonlat([10, 20, 30], step, 256, order=order)
     assert lon.shape == (3, 4 * step)

--- a/astropy_healpix/tests/test_healpy.py
+++ b/astropy_healpix/tests/test_healpy.py
@@ -1,6 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from itertools import product
-
 from astropy.coordinates import angular_separation
 from astropy import units as u
 import pytest
@@ -22,18 +20,16 @@ hp = pytest.importorskip("healpy")
 NSIDE_VALUES = [2**n for n in range(1, 6)]
 
 
-@pytest.mark.parametrize(
-    ("nside", "degrees"), list(product(NSIDE_VALUES, (False, True)))
-)
+@pytest.mark.parametrize("nside", NSIDE_VALUES)
+@pytest.mark.parametrize("degrees", [False, True])
 def test_nside2pixarea(nside, degrees):
     actual = hp_compat.nside2pixarea(nside=nside, degrees=degrees)
     expected = hp.nside2pixarea(nside=nside, degrees=degrees)
     assert_allclose(actual, expected)
 
 
-@pytest.mark.parametrize(
-    ("nside", "arcmin"), list(product(NSIDE_VALUES, (False, True)))
-)
+@pytest.mark.parametrize("nside", NSIDE_VALUES)
+@pytest.mark.parametrize("arcmin", [False, True])
 def test_nside2resol(nside, arcmin):
     actual = hp_compat.nside2resol(nside=nside, arcmin=arcmin)
     expected = hp.nside2resol(nside=nside, arcmin=arcmin)

--- a/astropy_healpix/tests/test_healpy.py
+++ b/astropy_healpix/tests/test_healpy.py
@@ -22,14 +22,18 @@ hp = pytest.importorskip("healpy")
 NSIDE_VALUES = [2**n for n in range(1, 6)]
 
 
-@pytest.mark.parametrize(("nside", "degrees"), product(NSIDE_VALUES, (False, True)))
+@pytest.mark.parametrize(
+    ("nside", "degrees"), list(product(NSIDE_VALUES, (False, True)))
+)
 def test_nside2pixarea(nside, degrees):
     actual = hp_compat.nside2pixarea(nside=nside, degrees=degrees)
     expected = hp.nside2pixarea(nside=nside, degrees=degrees)
     assert_allclose(actual, expected)
 
 
-@pytest.mark.parametrize(("nside", "arcmin"), product(NSIDE_VALUES, (False, True)))
+@pytest.mark.parametrize(
+    ("nside", "arcmin"), list(product(NSIDE_VALUES, (False, True)))
+)
 def test_nside2resol(nside, arcmin):
     actual = hp_compat.nside2resol(nside=nside, arcmin=arcmin)
     expected = hp.nside2resol(nside=nside, arcmin=arcmin)


### PR DESCRIPTION
This PR fixes a warning (turned error) in the CI: PytestRemovedIn10Warning: Passing a non-Collection iterable to parametrize is deprecated.

