### PR TITLE
Fix incorrect results from uniq_to_level_ipix near npix bounds

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,16 @@
 Changes
 *******
 
+2.0.0 (unreleased)
+==================
+
+- Require Numpy >= 2.
+
+- Fix incorrect return values of ``uniq_to_level_ipix`` near npix boundaries.
+
+- The functions ``nside_to_level`` and ``uniq_to_level_ipix`` no longer raise
+  exceptions for invalid input values. Instead, they return -1.
+
 1.1.3 (2026-01-19)
 ==================
 

--- a/astropy_healpix/_core.c
+++ b/astropy_healpix/_core.c
@@ -6,6 +6,12 @@
 #include "healpix-utils.h"
 #include "interpolation.h"
 
+#if __has_include(<stdbit.h>)
+    #include <stdbit.h>
+#elif defined(_MSC_VER)
+    #include <intrin.h>
+#endif
+
 /* FIXME: We need npy_set_floatstatus_invalid(), but unlike most of the Numpy
  * C API it is only available on some platforms if you explicitly link against
  * Numpy, which is not typically done for building C extensions. This bundled
@@ -294,6 +300,30 @@ static void neighbours_loop(
 }
 
 
+static void bit_scan_reverse_loop(
+    char **args, const npy_intp *dimensions, const npy_intp *steps, void *data)
+{
+    npy_intp i, n = dimensions[0];
+
+    for (i = 0; i < n; i ++)
+    {
+        int64_t  in = *(int64_t *) &args[0][i * steps[0]];
+        int    *out =  (int *)     &args[1][i * steps[1]];
+        #if __has_include(<stdbit.h>)
+            *out = 63 - stdc_leading_zeros(in);
+        #elif defined(_MSC_VER)
+            unsigned long index;
+            if (_BitScanReverse64(&index, in))
+                *out = index;
+            else
+                *out = -1;
+        #else
+            *out = 63 - __builtin_clzll(in);
+        #endif
+    }
+}
+
+
 static PyObject *healpix_cone_search(
     PyObject *self, PyObject *args, PyObject *kwargs)
 {
@@ -361,7 +391,8 @@ static PyUFuncGenericFunction
     nested_to_ring_loops                [] = {nested_to_ring_loop},
     ring_to_nested_loops                [] = {ring_to_nested_loop},
     bilinear_interpolation_weights_loops[] = {bilinear_interpolation_weights_loop},
-    neighbours_loops                    [] = {neighbours_loop};
+    neighbours_loops                    [] = {neighbours_loop},
+    bit_scan_reverse_loops              [] = {bit_scan_reverse_loop};
 
 static char
     healpix_to_lonlat_types[] = {
@@ -381,7 +412,8 @@ static char
     neighbours_types[] = {
         NPY_INT64, NPY_INT,
         NPY_INT64, NPY_INT64, NPY_INT64, NPY_INT64,
-        NPY_INT64, NPY_INT64, NPY_INT64, NPY_INT64};
+        NPY_INT64, NPY_INT64, NPY_INT64, NPY_INT64},
+    bit_scan_reverse_types[] = {NPY_INT64, NPY_INT};
 
 
 PyMODINIT_FUNC PyInit__core(void)
@@ -470,6 +502,12 @@ PyMODINIT_FUNC PyInit__core(void)
             neighbours_loops, ring_ufunc_data,
             neighbours_types, 1, 2, 8, PyUFunc_None,
             "neighbours_ring", NULL, 0));
+
+    PyModule_AddObject(
+        module, "bit_scan_reverse", PyUFunc_FromFuncAndData(
+            bit_scan_reverse_loops, no_ufunc_data,
+            bit_scan_reverse_types, 1, 1, 1, PyUFunc_None,
+            "bit_scan_reverse", NULL, 0));
 
     return module;
 }

--- a/astropy_healpix/core.py
+++ b/astropy_healpix/core.py
@@ -102,12 +102,10 @@ def nside_to_level(nside):
     Returns
     -------
     level : int
-        The level of the HEALPix cells
+        The level of the HEALPix cells, or -1 if the value of nside is invalid.
     """
-    nside = np.asarray(nside, dtype=np.int64)
-
-    _validate_nside(nside)
-    return np.log2(nside).astype(np.int64)
+    level = _core.bit_scan_reverse(nside)
+    return np.where((1 << level) == nside, level, -1)
 
 
 def uniq_to_level_ipix(uniq):
@@ -126,18 +124,14 @@ def uniq_to_level_ipix(uniq):
     Returns
     -------
     level, ipix: int, int
-        The level and index of the HEALPix cell computed from ``uniq``.
+        The level and index of the HEALPix cell computed from ``uniq``, or -1
+        if the input value is invalid.
     """
-    uniq = np.asarray(uniq, dtype=np.int64)
-
-    level = (np.log2(uniq // 4)) // 2
-    level = level.astype(np.int64)
-    _validate_level(level)
-
-    ipix = uniq - (1 << 2 * (level + 1))
-    _validate_npix(level, ipix)
-
-    return level, ipix
+    good = uniq >= 4
+    i = _core.bit_scan_reverse(uniq) >> 1
+    level = i - 1
+    ipix = uniq - (np.int64(1) << (i << 1))
+    return np.where(good, level, -1), np.where(good, ipix, -1)
 
 
 def level_ipix_to_uniq(level, ipix):

--- a/astropy_healpix/tests/test_core.py
+++ b/astropy_healpix/tests/test_core.py
@@ -36,11 +36,10 @@ def test_level_to_nside():
     assert exc.value.args[0] == "level must be positive"
 
 
-def test_nside_to_level():
-    assert nside_to_level(1024) == 10
-    with pytest.raises(ValueError) as exc:
-        nside_to_level(511)
-    assert exc.value.args[0] == "nside must be a power of two"
+@pytest.mark.parametrize("level", list(range(1, 30)))
+def test_nside_to_level(level):
+    nside = level_to_nside(level)
+    assert nside_to_level(nside) == level
 
 
 def test_level_ipix_to_uniq():
@@ -62,6 +61,17 @@ def test_uniq_to_level_ipix(level):
 
     level_res, ipix_res = uniq_to_level_ipix(level_ipix_to_uniq(level, ipix))
     assert np.all(level_res == level) & np.all(ipix_res == ipix)
+
+
+@pytest.mark.parametrize("level", [0, 5, 10, 15, 20, 22, 24, 25, 26, 27, 28, 29])
+def test_uniq_to_level_ipix_boundary(level):
+    # The last pixel of each level is the worst case for a floating-point level
+    # computation: uniq is just below a power of two, where log2 mis-rounds.
+    npix = 3 << 2 * (level + 1)
+    ipix = npix - 1
+    level_res, ipix_res = uniq_to_level_ipix(level_ipix_to_uniq(level, ipix))
+    assert level_res == level
+    assert ipix_res == ipix
 
 
 def test_nside_to_pixel_area():


### PR DESCRIPTION
Rewrite using `uniq_to_level_ipix` and `nside_to_level` using bitwise and integer arithmetic to fix all floating-point and rounding errors.

This is a reworking of #311.