### PR TITLE
Make return value of nside_to_level a 64-bit int

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,13 @@
 Changes
 *******
 
+2.0.1 (unreleased)
+==================
+
+- Have ``nside_to_level`` return a 64-bit integer. It is very common to use the
+  return value as a bit-shift argument which would cause truncation if the user
+  failed to first convert the return value to a 64-bit integer.
+
 2.0.0 (2026-06-29)
 ==================
 

--- a/astropy_healpix/_core.c
+++ b/astropy_healpix/_core.c
@@ -307,19 +307,21 @@ static void bit_scan_reverse_loop(
 
     for (i = 0; i < n; i ++)
     {
-        int64_t  in = *(int64_t *) &args[0][i * steps[0]];
-        int    *out =  (int *)     &args[1][i * steps[1]];
+        int64_t   in = *(int64_t *) &args[0][i * steps[0]];
+        int64_t *out =  (int *)     &args[1][i * steps[1]];
+        int result;
         #if __has_include(<stdbit.h>)
-            *out = 63 - stdc_leading_zeros(in);
+            result = 63 - stdc_leading_zeros(in);
         #elif defined(_MSC_VER)
             unsigned long index;
             if (_BitScanReverse64(&index, in))
-                *out = index;
+                result = index;
             else
-                *out = -1;
+                result = -1;
         #else
-            *out = 63 - __builtin_clzll(in);
+            result = 63 - __builtin_clzll(in);
         #endif
+        *out = result;
     }
 }
 
@@ -413,7 +415,7 @@ static char
         NPY_INT64, NPY_INT,
         NPY_INT64, NPY_INT64, NPY_INT64, NPY_INT64,
         NPY_INT64, NPY_INT64, NPY_INT64, NPY_INT64},
-    bit_scan_reverse_types[] = {NPY_INT64, NPY_INT};
+    bit_scan_reverse_types[] = {NPY_INT64, NPY_INT64};
 
 
 PyMODINIT_FUNC PyInit__core(void)

--- a/astropy_healpix/core.py
+++ b/astropy_healpix/core.py
@@ -130,7 +130,7 @@ def uniq_to_level_ipix(uniq):
     good = uniq >= 4
     i = _core.bit_scan_reverse(uniq) >> 1
     level = i - 1
-    ipix = uniq - (np.int64(1) << (i << 1))
+    ipix = uniq - (1 << (i << 1))
     return np.where(good, level, -1), np.where(good, ipix, -1)
 
 


### PR DESCRIPTION
It is very common to use the return value as a bit-shift argument which would cause truncation if the user failed to first convert the return value to a 64-bit integer.

See https://git.ligo.org/emfollow/userguide/-/merge_requests/332.