### PR TITLE
Fix compiler warnings due to unused arguments

### DIFF
--- a/astropy_healpix/_core.c
+++ b/astropy_healpix/_core.c
@@ -181,7 +181,7 @@ static void xyz_to_healpix_loop(
 
 
 static void nested_to_ring_loop(
-    char **args, const npy_intp *dimensions, const npy_intp *steps, void *data)
+    char **args, const npy_intp *dimensions, const npy_intp *steps, void *NPY_UNUSED(data))
 {
     npy_intp i, n = dimensions[0];
 
@@ -205,7 +205,7 @@ static void nested_to_ring_loop(
 
 
 static void ring_to_nested_loop(
-    char **args, const npy_intp *dimensions, const npy_intp *steps, void *data)
+    char **args, const npy_intp *dimensions, const npy_intp *steps, void *NPY_UNUSED(data))
 {
     npy_intp i, n = dimensions[0];
 
@@ -229,7 +229,7 @@ static void ring_to_nested_loop(
 
 
 static void bilinear_interpolation_weights_loop(
-    char **args, const npy_intp *dimensions, const npy_intp *steps, void *data)
+    char **args, const npy_intp *dimensions, const npy_intp *steps, void *NPY_UNUSED(data))
 {
     npy_intp i, n = dimensions[0];
 
@@ -301,7 +301,7 @@ static void neighbours_loop(
 
 
 static void bit_scan_reverse_loop(
-    char **args, const npy_intp *dimensions, const npy_intp *steps, void *data)
+    char **args, const npy_intp *dimensions, const npy_intp *steps, void *NPY_UNUSED(data))
 {
     npy_intp i, n = dimensions[0];
 
@@ -327,7 +327,7 @@ static void bit_scan_reverse_loop(
 
 
 static PyObject *healpix_cone_search(
-    PyObject *self, PyObject *args, PyObject *kwargs)
+    PyObject *NPY_UNUSED(self), PyObject *args, PyObject *kwargs)
 {
     PyObject *result;
     static char *kws[] = {"lon", "lat", "radius", "nside", "order", NULL};


### PR DESCRIPTION
Revealed by compiling with `-Wall`.